### PR TITLE
[WAL-82] Check no balance: APPC and APPC-C

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -362,15 +362,11 @@ public class InAppPurchaseInteractor {
       appcReason = -1;
     }
     if (!creditsMethod.isEnabled() && !appcMethod.isEnabled()) {
-      // Specific cases to treat differently:
+      // Specific cases that are treated differently:
       // - If user does not have APPC-C, has APPC, but no ETH, the message should be to display
-      //    that user does not have ETH
-      // - If user does not have APPC-C nor APPC, the message should be indicating that user
-      //  does not have funds
-      // TODO - change purchase_no_eth_body to a shorter string (not yet in strings.xml) indicating:
-      //    "You need ETH to pay for the gas"
-      //  Also, change p2p_send_error_not_enough_funds to an actual string (not yet in strings.xml)
-      //    related to purchase flow, indicating that the user does not have enough funds
+      //    that user does not have enough ETH (may have none, or some but not enough)
+      // - If user does not have APPC-C nor APPC (ETH value doesn't matter),
+      //    the message should be more generic, indicating that user does not have funds
       return (appcReason == R.string.purchase_no_eth_body) ? appcReason :
           R.string.p2p_send_error_not_enough_funds;
     }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -353,22 +353,28 @@ public class InAppPurchaseInteractor {
   }
 
   private Integer mergeDisableReason(PaymentMethod appcMethod, PaymentMethod creditsMethod) {
-    Integer reason = null;
-
-    if (!creditsMethod.isEnabled()) {
-      if (creditsMethod.getDisabledReason() != -1) {
-        reason = creditsMethod.getDisabledReason();
-      } else {
-        reason = appcMethod.getDisabledReason();
-      }
-    } else if (!appcMethod.isEnabled()) {
-      if (appcMethod.getDisabledReason() != -1) {
-        reason = appcMethod.getDisabledReason();
-      } else {
-        reason = creditsMethod.getDisabledReason();
-      }
+    Integer creditsReason = creditsMethod.getDisabledReason();
+    Integer appcReason = appcMethod.getDisabledReason();
+    // Specific cases to treat differently:
+    // - If user does not have APPC-C, has APPC, but no ETH, the message should be to display
+    //    that user does not have ETH
+    // - If user does not have APPC-C nor APPC, the message should be indicating that user
+    //  does not have funds
+    // TODO - change purchase_no_eth_body to a shorter string (not yet in strings.xml) indicating:
+    //    "You need ETH to pay for the gas"
+    //  Also, change p2p_send_error_not_enough_funds to an actual string (not yet in strings.xml)
+    //    related to purchase flow, indicating that the user does not have enough funds
+    if(!creditsMethod.isEnabled() && !appcMethod.isEnabled()) {
+      return (appcReason == R.string.purchase_no_eth_body) ? appcReason :
+          R.string.p2p_send_error_not_enough_funds;
     }
-    return reason;
+    if (!creditsMethod.isEnabled()) {
+      return (creditsReason != -1) ? creditsReason : appcReason;
+    }
+    if (!appcMethod.isEnabled()) {
+      return (appcReason != -1) ? appcReason : creditsReason;
+    }
+    return null;
   }
 
   private PaymentMethod getCreditsMethod(List<PaymentMethod> paymentMethods) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -355,10 +355,10 @@ public class InAppPurchaseInteractor {
   private Integer mergeDisableReason(PaymentMethod appcMethod, PaymentMethod creditsMethod) {
     Integer creditsReason = creditsMethod.getDisabledReason();
     Integer appcReason = appcMethod.getDisabledReason();
-    if (creditsReason==null) {
+    if (creditsReason == null) {
       creditsReason = -1;
     }
-    if (appcReason==null) {
+    if (appcReason == null) {
       appcReason = -1;
     }
     if (!creditsMethod.isEnabled() && !appcMethod.isEnabled()) {
@@ -367,8 +367,8 @@ public class InAppPurchaseInteractor {
       //    that user does not have enough ETH (may have none, or some but not enough)
       // - If user does not have APPC-C nor APPC (ETH value doesn't matter),
       //    the message should be more generic, indicating that user does not have funds
-      return (appcReason == R.string.purchase_no_eth_body) ? appcReason :
-          R.string.p2p_send_error_not_enough_funds;
+      return (appcReason == R.string.purchase_no_eth_body) ? appcReason
+          : R.string.p2p_send_error_not_enough_funds;
     }
     if (!creditsMethod.isEnabled()) {
       return (creditsReason != -1) ? creditsReason : appcReason;

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -355,16 +355,22 @@ public class InAppPurchaseInteractor {
   private Integer mergeDisableReason(PaymentMethod appcMethod, PaymentMethod creditsMethod) {
     Integer creditsReason = creditsMethod.getDisabledReason();
     Integer appcReason = appcMethod.getDisabledReason();
-    // Specific cases to treat differently:
-    // - If user does not have APPC-C, has APPC, but no ETH, the message should be to display
-    //    that user does not have ETH
-    // - If user does not have APPC-C nor APPC, the message should be indicating that user
-    //  does not have funds
-    // TODO - change purchase_no_eth_body to a shorter string (not yet in strings.xml) indicating:
-    //    "You need ETH to pay for the gas"
-    //  Also, change p2p_send_error_not_enough_funds to an actual string (not yet in strings.xml)
-    //    related to purchase flow, indicating that the user does not have enough funds
-    if(!creditsMethod.isEnabled() && !appcMethod.isEnabled()) {
+    if (creditsReason==null) {
+      creditsReason = -1;
+    }
+    if (appcReason==null) {
+      appcReason = -1;
+    }
+    if (!creditsMethod.isEnabled() && !appcMethod.isEnabled()) {
+      // Specific cases to treat differently:
+      // - If user does not have APPC-C, has APPC, but no ETH, the message should be to display
+      //    that user does not have ETH
+      // - If user does not have APPC-C nor APPC, the message should be indicating that user
+      //  does not have funds
+      // TODO - change purchase_no_eth_body to a shorter string (not yet in strings.xml) indicating:
+      //    "You need ETH to pay for the gas"
+      //  Also, change p2p_send_error_not_enough_funds to an actual string (not yet in strings.xml)
+      //    related to purchase flow, indicating that the user does not have enough funds
       return (appcReason == R.string.purchase_no_eth_body) ? appcReason :
           R.string.p2p_send_error_not_enough_funds;
     }


### PR DESCRIPTION
**What does this PR do?**

   Bugfix related to not showing the right reason why AppCoins / AppCoins Credits option is disabled in In-App purchase flow. The following changes were made:
   - When user has enough AppCoins to buy the item, but doesn't have AppCoins Credits nor ETH to pay the fee, message to display was changed to indicate that user doesn't have ETH
   - When user doesn't have enough AppCoins nor AppCoins Credits (independently of having ETH or not), the message to display was changed to indicate that user doesn't have enough funds

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InAppPurchaseInteractor.java

**How should this be manually tested?**

  Check if above use cases are working as intended. Check if other use cases related to inability to use APPC in IAP were not broken.

**What are the relevant tickets?**

  Tickets related to this pull-request: [WAL-82](https://aptoide.atlassian.net/browse/WAL-82)

**Questions:**



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass