### PR TITLE
[WAL-104] Rever changes made on DP conversion

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -585,7 +585,12 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
   }
 
   private fun getTopUpValuesSpanCount(): Int {
-    val screenWidth = fragmentContainer.measuredWidth.convertDpToPx(resources)
+    val screenWidth =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX,
+            fragmentContainer.measuredWidth.toFloat(),
+            requireContext().resources
+                .displayMetrics)
+            .toInt()
     val viewWidth = 80.convertDpToPx(resources)
 
     return screenWidth / viewWidth

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpItemDecorator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpItemDecorator.kt
@@ -1,6 +1,7 @@
 package com.asfoundation.wallet.topup
 
 import android.graphics.Rect
+import android.util.TypedValue
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import com.asfoundation.wallet.util.convertDpToPx
@@ -15,7 +16,11 @@ class TopUpItemDecorator(private val size: Int, private val addMargin: Boolean) 
       val position: Int = parent.getChildAdapterPosition(view)
       val spanCount = size
 
-      val screenWidth = parent.measuredWidth.convertDpToPx(parent.context.resources)
+      val screenWidth =
+          TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, parent.measuredWidth.toFloat(),
+              parent.context.resources
+                  .displayMetrics)
+              .toInt()
       val viewWidth = 80.convertDpToPx(parent.context.resources)
 
       val spacing = (((screenWidth - viewWidth * spanCount) / (spanCount + 1)) * 0.99).toInt()

--- a/app/src/main/java/com/asfoundation/wallet/ui/appcoins/CardNotificationsItemDecorator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/appcoins/CardNotificationsItemDecorator.kt
@@ -1,6 +1,7 @@
 package com.asfoundation.wallet.ui.appcoins
 
 import android.graphics.Rect
+import android.util.TypedValue
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import com.asfoundation.wallet.util.convertDpToPx
@@ -39,7 +40,11 @@ class CardNotificationsItemDecorator : RecyclerView.ItemDecoration() {
 
       val margins = 32.convertDpToPx(parent.context.resources)
 
-      val screenWidth = parent.measuredWidth.convertDpToPx(parent.context.resources)
+      val screenWidth =
+          TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, parent.measuredWidth.toFloat(),
+              parent.context.resources
+                  .displayMetrics)
+              .toInt()
 
       val cardWidth = if (screenWidth > maxWidth) {
         maxWidth


### PR DESCRIPTION
**What does this PR do?**

On a previous PR while extracting dpToPx conversions to an extension function, some other conversions were extracted too. This PR aims to revert those.
This was visible in the notification cards when there were no transactions.

**Database changed?**

   No

**Where should the reviewer start?**

CardNotificationsItemDecorator.kt

**How should this be manually tested?**

Check if the cards on home without transactions appear correctly
**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/WAL-104

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass