### PR TITLE
[feature/WAL-131] Billing Address remembered

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -244,6 +244,8 @@ dependencies {
 
   implementation "androidx.biometric:biometric:$project.biometrics_version"
 
+  implementation "androidx.security:security-crypto:$project.securitycrypto_version"
+
   testImplementation "junit:junit:$project.junit_version"
   testImplementation "org.mockito:mockito-core:$project.mockito_version"
   androidTestImplementation "androidx.test.ext:junit:$project.test_ext_version"

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressFragment.kt
@@ -100,12 +100,6 @@ class BillingAddressFragment : DaggerFragment(), BillingAddressView {
     savedBillingAddress?.let { setupSavedBillingAddress(savedBillingAddress) }
     setupFieldsListener()
     setupStateAdapter()
-    if (isStored) {
-      remember.visibility = GONE
-    } else {
-      remember.visibility = VISIBLE
-      remember.isChecked = shouldStoreCard
-    }
   }
 
   private fun setupSavedBillingAddress(savedBillingAddress: BillingAddressModel) {
@@ -152,7 +146,7 @@ class BillingAddressFragment : DaggerFragment(), BillingAddressView {
               state.text.toString(),
               country.text.toString(),
               number.text.toString(),
-              remember.isChecked
+              false
           )
         }
   }

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressFragment.kt
@@ -86,21 +86,35 @@ class BillingAddressFragment : DaggerFragment(), BillingAddressView {
     presenter.present()
   }
 
-  override fun initializeView(bonus: String?, isDonation: Boolean, domain: String,
+  override fun initializeView(bonus: String?, isDonation: Boolean,
+                              domain: String,
                               skuDescription: String,
                               appcAmount: BigDecimal, fiatAmount: BigDecimal,
-                              fiatCurrency: String, isStored: Boolean, shouldStoreCard: Boolean) {
+                              fiatCurrency: String, isStored: Boolean,
+                              shouldStoreCard: Boolean,
+                              savedBillingAddress: BillingAddressModel?) {
     iabView.unlockRotation()
     showButtons(isDonation)
     setHeaderInformation(isDonation, domain, skuDescription, appcAmount, fiatAmount, fiatCurrency)
     showBonus(bonus)
+    savedBillingAddress?.let { setupSavedBillingAddress(savedBillingAddress) }
     setupFieldsListener()
     setupStateAdapter()
-    if (isStored) remember.visibility = GONE
-    else {
+    if (isStored) {
+      remember.visibility = GONE
+    } else {
       remember.visibility = VISIBLE
       remember.isChecked = shouldStoreCard
     }
+  }
+
+  private fun setupSavedBillingAddress(savedBillingAddress: BillingAddressModel) {
+    address.setText(savedBillingAddress.address)
+    city.setText(savedBillingAddress.city)
+    zipcode.setText(savedBillingAddress.zipcode)
+    state.setText(savedBillingAddress.state)
+    country.setText(savedBillingAddress.country)
+    number.setText(savedBillingAddress.number)
   }
 
   private fun showButtons(isDonation: Boolean) {

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressModule.kt
@@ -20,9 +20,10 @@ class BillingAddressModule {
   fun providesBillingAddressPresenter(fragment: BillingAddressFragment,
                                       navigator: BillingAddressNavigator,
                                       data: BillingAddressData,
+                                      billingAddressRepository: BillingAddressRepository,
                                       billingAnalytics: BillingAnalytics): BillingAddressPresenter {
-    return BillingAddressPresenter(fragment, data, navigator, billingAnalytics,
-        CompositeDisposable(), AndroidSchedulers.mainThread())
+    return BillingAddressPresenter(fragment, data, navigator, billingAddressRepository,
+        billingAnalytics, CompositeDisposable(), AndroidSchedulers.mainThread())
   }
 
   @Provides

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressPresenter.kt
@@ -30,9 +30,15 @@ class BillingAddressPresenter(
         view.submitClicks()
             .subscribeOn(viewScheduler)
             .doOnNext { billingAddressModel ->
-              billingAddressRepository.saveBillingAddress(billingAddressModel)
+              val billingModel =
+                  BillingAddressModel(billingAddressModel.address, billingAddressModel.city,
+                      billingAddressModel.zipcode, billingAddressModel.state,
+                      billingAddressModel.country, billingAddressModel.number, data.shouldStoreCard)
+              if (data.shouldStoreCard) {
+                billingAddressRepository.saveBillingAddress(billingModel)
+              }
               sendActionEventAnalytics(if (data.isDonation) "donate" else "buy")
-              navigator.finishWithSuccess(billingAddressModel)
+              navigator.finishWithSuccess(billingModel)
             }
             .subscribe({}, { it.printStackTrace() })
     )

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressPresenter.kt
@@ -8,6 +8,7 @@ class BillingAddressPresenter(
     private val view: BillingAddressView,
     private val data: BillingAddressData,
     private val navigator: BillingAddressNavigator,
+    private val billingAddressRepository: BillingAddressRepository,
     private val billingAnalytics: BillingAnalytics,
     private val disposables: CompositeDisposable,
     private val viewScheduler: Scheduler) {
@@ -20,7 +21,8 @@ class BillingAddressPresenter(
 
   private fun initializeView() {
     view.initializeView(data.bonus, data.isDonation, data.domain, data.skuDescription,
-        data.appcAmount, data.fiatAmount, data.fiatCurrency, data.isStored, data.shouldStoreCard)
+        data.appcAmount, data.fiatAmount, data.fiatCurrency, data.isStored, data.shouldStoreCard,
+        billingAddressRepository.retrieveBillingAddress())
   }
 
   private fun handleSubmitClicks() {
@@ -28,6 +30,7 @@ class BillingAddressPresenter(
         view.submitClicks()
             .subscribeOn(viewScheduler)
             .doOnNext { billingAddressModel ->
+              billingAddressRepository.saveBillingAddress(billingAddressModel)
               sendActionEventAnalytics(if (data.isDonation) "donate" else "buy")
               navigator.finishWithSuccess(billingAddressModel)
             }

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressRepository.kt
@@ -1,0 +1,45 @@
+package com.asfoundation.wallet.billing.address
+
+import com.asfoundation.wallet.repository.SecureSharedPreferences
+import com.asfoundation.wallet.util.component6
+import com.asfoundation.wallet.util.guardLet
+
+class BillingAddressRepository(private val secureSharedPreferences: SecureSharedPreferences) {
+
+  companion object {
+    private const val BILLING_ADDRESS_PREFIX = "billing_address"
+  }
+
+  fun saveBillingAddress(billingAddressModel: BillingAddressModel) {
+    secureSharedPreferences.saveStrings(
+        Pair("${BILLING_ADDRESS_PREFIX}.address", billingAddressModel.address),
+        Pair("${BILLING_ADDRESS_PREFIX}.city", billingAddressModel.city),
+        Pair("${BILLING_ADDRESS_PREFIX}.zipcode", billingAddressModel.zipcode),
+        Pair("${BILLING_ADDRESS_PREFIX}.state", billingAddressModel.state),
+        Pair("${BILLING_ADDRESS_PREFIX}.country", billingAddressModel.country),
+        Pair("${BILLING_ADDRESS_PREFIX}.number", billingAddressModel.number)
+    )
+  }
+
+  /**
+   * Retrieves a saved billing address. Note that this does not store whether the card should be
+   * saved or not, this field will always be returned as false.
+   *
+   * @return BillingAddressModel or null if any field could not be retrieved
+   */
+  fun retrieveBillingAddress(): BillingAddressModel? {
+    val (address, city, zipcode, state, country, number) = guardLet(
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.address", null),
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.city", null),
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.zipcode", null),
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.state", null),
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.country", null),
+        secureSharedPreferences.getString("${BILLING_ADDRESS_PREFIX}.number", null)
+    ) {
+      return null
+    }
+    return BillingAddressModel(address, city, zipcode, state, country, number, false)
+  }
+}
+
+

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressRepository.kt
@@ -21,6 +21,15 @@ class BillingAddressRepository(private val secureSharedPreferences: SecureShared
     )
   }
 
+  fun forgetBillingAddress() {
+    secureSharedPreferences.remove("${BILLING_ADDRESS_PREFIX}.address",
+        "${BILLING_ADDRESS_PREFIX}.city",
+        "${BILLING_ADDRESS_PREFIX}.zipcode",
+        "${BILLING_ADDRESS_PREFIX}.state",
+        "${BILLING_ADDRESS_PREFIX}.country",
+        "${BILLING_ADDRESS_PREFIX}.number")
+  }
+
   /**
    * Retrieves a saved billing address. Note that this does not store whether the card should be
    * saved or not, this field will always be returned as false.

--- a/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/address/BillingAddressView.kt
@@ -5,9 +5,12 @@ import java.math.BigDecimal
 
 interface BillingAddressView {
 
-  fun initializeView(bonus: String?, isDonation: Boolean, domain: String, skuDescription: String,
-                     appcAmount: BigDecimal, fiatAmount: BigDecimal, fiatCurrency: String,
-                     isStored: Boolean, shouldStoreCard: Boolean)
+  fun initializeView(bonus: String?, isDonation: Boolean, domain: String,
+                     skuDescription: String,
+                     appcAmount: BigDecimal, fiatAmount: BigDecimal,
+                     fiatCurrency: String,
+                     isStored: Boolean, shouldStoreCard: Boolean,
+                     savedBillingAddress: BillingAddressModel?)
 
   fun backClicks(): Observable<Any>
 

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentInteractor.kt
@@ -11,6 +11,7 @@ import com.appcoins.wallet.billing.adyen.PaymentInfoModel
 import com.appcoins.wallet.billing.adyen.PaymentModel
 import com.appcoins.wallet.billing.common.response.TransactionStatus
 import com.appcoins.wallet.billing.util.Error
+import com.asfoundation.wallet.billing.address.BillingAddressRepository
 import com.asfoundation.wallet.billing.partners.AddressService
 import com.asfoundation.wallet.interact.SmsValidationInteract
 import com.asfoundation.wallet.support.SupportInteractor
@@ -35,8 +36,11 @@ class AdyenPaymentInteractor(
     private val walletService: WalletService,
     private val supportInteractor: SupportInteractor,
     private val walletBlockedInteract: WalletBlockedInteract,
-    private val smsValidationInteract: SmsValidationInteract
+    private val smsValidationInteract: SmsValidationInteract,
+    private val billingAddressRepository: BillingAddressRepository
 ) {
+
+  fun forgetBillingAddress() = billingAddressRepository.forgetBillingAddress()
 
   fun isWalletBlocked() = walletBlockedInteract.isWalletBlocked()
 

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
@@ -100,6 +100,7 @@ class AdyenPaymentPresenter(private val view: AdyenPaymentView,
               amount.toString(), currency)
               .observeOn(viewScheduler)
               .doOnSuccess {
+                adyenPaymentInteractor.forgetBillingAddress()
                 view.hideLoadingAndShowView()
                 if (it.error.hasError) {
                   if (it.error.isNetworkError) view.showNetworkError()

--- a/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
@@ -587,4 +587,10 @@ internal class AppModule {
       abTestInteractor: ABTestInteractor): BalanceWalletsExperiment {
     return BalanceWalletsExperiment(abTestInteractor)
   }
+
+  @Singleton
+  @Provides
+  fun providesSecureSharedPreferences(context: Context): SecureSharedPreferences {
+    return SecureSharedPreferences(context)
+  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
@@ -34,6 +34,7 @@ import com.asfoundation.wallet.analytics.LaunchInteractor
 import com.asfoundation.wallet.backup.BackupInteract
 import com.asfoundation.wallet.backup.BackupInteractContract
 import com.asfoundation.wallet.backup.FileInteractor
+import com.asfoundation.wallet.billing.address.BillingAddressRepository
 import com.asfoundation.wallet.billing.adyen.AdyenPaymentInteractor
 import com.asfoundation.wallet.billing.partners.AddressService
 import com.asfoundation.wallet.billing.purchase.InAppDeepLinkRepository
@@ -246,10 +247,12 @@ class InteractorModule {
                                     walletService: WalletService,
                                     supportInteractor: SupportInteractor,
                                     walletBlockedInteract: WalletBlockedInteract,
-                                    smsValidationInteract: SmsValidationInteract): AdyenPaymentInteractor {
+                                    smsValidationInteract: SmsValidationInteract,
+                                    billingAddressRepository: BillingAddressRepository): AdyenPaymentInteractor {
     return AdyenPaymentInteractor(adyenPaymentRepository, inAppPurchaseInteractor,
         inAppPurchaseInteractor.billingMessagesMapper, partnerAddressService, billing,
-        walletService, supportInteractor, walletBlockedInteract, smsValidationInteract)
+        walletService, supportInteractor, walletBlockedInteract, smsValidationInteract,
+        billingAddressRepository)
   }
 
   @Provides

--- a/app/src/main/java/com/asfoundation/wallet/di/RepositoryModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/RepositoryModule.kt
@@ -21,6 +21,7 @@ import com.asfoundation.wallet.App
 import com.asfoundation.wallet.abtesting.*
 import com.asfoundation.wallet.analytics.AmplitudeAnalytics
 import com.asfoundation.wallet.analytics.RakamAnalytics
+import com.asfoundation.wallet.billing.address.BillingAddressRepository
 import com.asfoundation.wallet.billing.partners.InstallerService
 import com.asfoundation.wallet.billing.purchase.InAppDeepLinkRepository
 import com.asfoundation.wallet.billing.purchase.LocalPaymentsLinkRepository
@@ -308,5 +309,12 @@ class RepositoryModule {
   fun providesGasPreferenceRepository(
       sharedPreferences: SharedPreferences): GasPreferenceRepository {
     return GasPreferenceRepository(sharedPreferences)
+  }
+
+  @Singleton
+  @Provides
+  fun providesBillingAddressRepository(
+      secureSharedPreferences: SecureSharedPreferences): BillingAddressRepository {
+    return BillingAddressRepository(secureSharedPreferences)
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/repository/SecureSharedPreferences.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SecureSharedPreferences.kt
@@ -29,6 +29,14 @@ class SecureSharedPreferences(private val context: Context) {
         .apply()
   }
 
+  fun remove(vararg keys: String) {
+    sharedPreferences.edit()
+        .apply {
+          keys.forEach { key -> remove(key) }
+        }
+        .apply()
+  }
+
   /**
    * Saves list of strings denoted as pairs of <Key, Value>
    */

--- a/app/src/main/java/com/asfoundation/wallet/repository/SecureSharedPreferences.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SecureSharedPreferences.kt
@@ -1,0 +1,48 @@
+package com.asfoundation.wallet.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Used to store and retrieve sensitive data as SharedPreferences
+ */
+class SecureSharedPreferences(private val context: Context) {
+
+  companion object {
+    const val FILE_NAME = "sec_shr_prf"
+  }
+
+  val sharedPreferences: SharedPreferences by lazy {
+    val masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+    EncryptedSharedPreferences.create(context, FILE_NAME, masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV, EncryptedSharedPreferences
+        .PrefValueEncryptionScheme.AES256_GCM)
+  }
+
+  fun saveString(key: String, value: String) {
+    sharedPreferences.edit()
+        .putString(key, value)
+        .apply()
+  }
+
+  /**
+   * Saves list of strings denoted as pairs of <Key, Value>
+   */
+  fun saveStrings(vararg values: Pair<String, String>) {
+    sharedPreferences.edit()
+        .apply {
+          values.forEach { pair -> putString(pair.first, pair.second) }
+        }
+        .apply()
+  }
+
+  fun getString(key: String, defValue: String?): String? =
+      sharedPreferences.getString(key, defValue)
+
+  fun getBoolean(key: String, defValue: Boolean): Boolean =
+      sharedPreferences.getBoolean(key, defValue)
+}

--- a/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
@@ -71,18 +71,25 @@ class BillingAddressTopUpFragment : DaggerFragment(), BillingAddressTopUpView {
     presenter.present()
   }
 
-  override fun initializeView(data: TopUpPaymentData, fiatAmount: String, fiatCurrency: String,
-                              shouldStoreCard: Boolean, isStored: Boolean) {
+  override fun initializeView(data: TopUpPaymentData,
+                              fiatAmount: String, fiatCurrency: String,
+                              shouldStoreCard: Boolean, isStored: Boolean,
+                              savedBillingAddress: BillingAddressModel?) {
     showBonus(data)
     showValues(data, fiatAmount, fiatCurrency)
+    savedBillingAddress?.let { setupSavedBillingAddress(savedBillingAddress) }
     setupFieldsListener()
     setupStateAdapter()
     button.setText(R.string.topup_home_button)
-    if (isStored) remember.visibility = View.GONE
-    else {
-      remember.visibility = VISIBLE
-      remember.isChecked = shouldStoreCard
-    }
+  }
+
+  private fun setupSavedBillingAddress(savedBillingAddress: BillingAddressModel) {
+    address.setText(savedBillingAddress.address)
+    city.setText(savedBillingAddress.city)
+    zipcode.setText(savedBillingAddress.zipcode)
+    state.setText(savedBillingAddress.state)
+    country.setText(savedBillingAddress.country)
+    number.setText(savedBillingAddress.number)
   }
 
   private fun setupFieldsListener() {
@@ -116,7 +123,7 @@ class BillingAddressTopUpFragment : DaggerFragment(), BillingAddressTopUpView {
               state.text.toString(),
               country.text.toString(),
               number.text.toString(),
-              remember.isChecked
+              false
           )
         }
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpModule.kt
@@ -1,5 +1,6 @@
 package com.asfoundation.wallet.topup.address
 
+import com.asfoundation.wallet.billing.address.BillingAddressRepository
 import com.asfoundation.wallet.topup.TopUpActivityView
 import com.asfoundation.wallet.topup.TopUpAnalytics
 import com.asfoundation.wallet.topup.TopUpPaymentData
@@ -29,9 +30,10 @@ class BillingAddressTopUpModule {
   fun providesBillingAddressTopUpPresenter(fragment: BillingAddressTopUpFragment,
                                            data: BillingAddressTopUpData,
                                            navigator: BillingAddressTopUpNavigator,
+                                           billingAddressRepository: BillingAddressRepository,
                                            topUpAnalytics: TopUpAnalytics): BillingAddressTopUpPresenter {
     return BillingAddressTopUpPresenter(fragment, data, CompositeDisposable(),
-        AndroidSchedulers.mainThread(), navigator, topUpAnalytics)
+        AndroidSchedulers.mainThread(), navigator, billingAddressRepository, topUpAnalytics)
   }
 
   @Provides

--- a/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpView.kt
@@ -14,6 +14,8 @@ interface BillingAddressTopUpView {
 
   fun finishSuccess(billingAddressModel: BillingAddressModel)
 
-  fun initializeView(data: TopUpPaymentData, fiatAmount: String, fiatCurrency: String,
-                     shouldStoreCard: Boolean, isStored: Boolean)
+  fun initializeView(data: TopUpPaymentData,
+                     fiatAmount: String, fiatCurrency: String,
+                     shouldStoreCard: Boolean, isStored: Boolean,
+                     savedBillingAddress: BillingAddressModel?)
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
@@ -235,6 +235,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
               amount, currency)
               .observeOn(viewScheduler)
               .doOnSuccess {
+                adyenPaymentInteractor.forgetBillingAddress()
                 view.hideLoading()
                 if (it.error.hasError) {
                   if (it.error.isNetworkError) view.showNetworkError()

--- a/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
@@ -118,6 +118,11 @@ inline fun <T : Any> guardLet(vararg elements: T?, closure: () -> Nothing): List
 }
 
 /**
+ * List by default can only destructure up to 5 components, this lets it go up to 6.
+ */
+operator fun <T> List<T>.component6() = get(5)
+
+/**
  * Executes block function with no layout transition animations. Note that it assumes that there is
  * no LayoutTransition.CHANGING, which is the case by default in "animateLayoutChanges".
  *

--- a/app/src/main/res/layout-land/layout_billing_address.xml
+++ b/app/src/main/res/layout-land/layout_billing_address.xml
@@ -132,16 +132,4 @@
 
   </com.google.android.material.textfield.TextInputLayout>
 
-  <com.google.android.material.switchmaterial.SwitchMaterial
-      android:id="@+id/remember"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:backgroundTint="@color/billing_switch_color"
-      android:text="@string/dialog_credit_card_remember"
-      android:textSize="14sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/country_layout"
-      />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_billing_address.xml
+++ b/app/src/main/res/layout/layout_billing_address.xml
@@ -132,16 +132,4 @@
 
   </com.google.android.material.textfield.TextInputLayout>
 
-  <com.google.android.material.switchmaterial.SwitchMaterial
-      android:id="@+id/remember"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:backgroundTint="@color/billing_switch_color"
-      android:text="@string/dialog_credit_card_remember"
-      android:textSize="14sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/country_layout"
-      />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ project.ext {
   amplitude_version = '2.25.2'
   corektx_version = '1.3.2'
   work_version = '2.4.0'
+  securitycrypto_version = '1.1.0-alpha03'
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
**What does this PR do?**

   This PR saves billing address when inputted correctly and auto-fills it for the next purchase. This info is encrypted with the androidx.security library.

**Database changed?**

   No

**How should this be manually tested?**

  Get an Adyen test card and a proxy to US. Then simply make two credit card purchases. For the second purchase, it should remember the billing address info.

**What are the relevant tickets?**

  [WAL-131](https://aptoide.atlassian.net/browse/WAL-131)

**Notes:**

   It adds the "new" androidx.security library. Please note that the version is in alpha for a good reason: it is the version that supports API 21 and 22 (the other RC only supports 23+).

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass