### PR TITLE
[WAL-98] - Fix bug when pressing back from BillingAddressTopUpFragmen…

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -237,10 +237,6 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun getTryAgainClicks() = RxView.clicks(try_again)
 
-  override fun setFinishingPurchase(value: Boolean) {
-    isFinishingPurchase = value
-  }
-
   override fun cancelPayment() {
     if (supportFragmentManager.backStackEntryCount != 0) {
       supportFragmentManager.popBackStackImmediate()

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -237,8 +237,8 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun getTryAgainClicks() = RxView.clicks(try_again)
 
-  override fun setFinishingPurchase() {
-    isFinishingPurchase = true
+  override fun setFinishingPurchase(value: Boolean) {
+    isFinishingPurchase = value
   }
 
   override fun cancelPayment() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -237,6 +237,10 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun getTryAgainClicks() = RxView.clicks(try_again)
 
+  override fun setFinishingPurchase(newState: Boolean) {
+    isFinishingPurchase = newState
+  }
+
   override fun cancelPayment() {
     if (supportFragmentManager.backStackEntryCount != 0) {
       supportFragmentManager.popBackStackImmediate()

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -37,6 +37,8 @@ interface TopUpActivityView {
 
   fun cancelPayment()
 
+  fun setFinishingPurchase(value: Boolean)
+
   fun showError(@StringRes error: Int)
 
   fun getSupportClicks(): Observable<Any>

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -37,8 +37,6 @@ interface TopUpActivityView {
 
   fun cancelPayment()
 
-  fun setFinishingPurchase(value: Boolean)
-
   fun showError(@StringRes error: Int)
 
   fun getSupportClicks(): Observable<Any>

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -37,7 +37,7 @@ interface TopUpActivityView {
 
   fun cancelPayment()
 
-  fun setFinishingPurchase()
+  fun setFinishingPurchase(value: Boolean)
 
   fun showError(@StringRes error: Int)
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
@@ -68,6 +68,7 @@ class BillingAddressTopUpFragment : DaggerFragment(), BillingAddressTopUpView {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    topUpView.setFinishingPurchase(false)
     presenter.present()
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/address/BillingAddressTopUpFragment.kt
@@ -68,7 +68,6 @@ class BillingAddressTopUpFragment : DaggerFragment(), BillingAddressTopUpView {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    topUpView.setFinishingPurchase(false)
     presenter.present()
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
@@ -287,6 +287,9 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
     topUpView.unlockRotation()
     topUpView.navigateToBillingAddress(data, fiatAmount, fiatCurrency, this,
         adyenSaveDetailsSwitch?.isChecked ?: true, isStored)
+    // To allow back behaviour when address input is needed
+    hideLoading()
+    button.isEnabled = true
   }
 
   override fun finishCardConfiguration(
@@ -392,7 +395,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
 
   override fun cancelPayment() = topUpView.cancelPayment()
 
-  override fun setFinishingPurchase() = topUpView.setFinishingPurchase()
+  override fun setFinishingPurchase() = topUpView.setFinishingPurchase(true)
 
   private fun setStoredPaymentInformation(isStored: Boolean) {
     if (isStored) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
@@ -395,7 +395,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
 
   override fun cancelPayment() = topUpView.cancelPayment()
 
-  override fun setFinishingPurchase() = topUpView.setFinishingPurchase(true)
+  override fun setFinishingPurchase() = presenter.setFinishingPurchase(true)
 
   private fun setStoredPaymentInformation(isStored: Boolean) {
     if (isStored) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
@@ -395,7 +395,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
 
   override fun cancelPayment() = topUpView.cancelPayment()
 
-  override fun setFinishingPurchase(newState: Boolean) = topUpView.setFinishingPurchase(true)
+  override fun setFinishingPurchase(newState: Boolean) = topUpView.setFinishingPurchase(newState)
 
   private fun setStoredPaymentInformation(isStored: Boolean) {
     if (isStored) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpFragment.kt
@@ -395,7 +395,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
 
   override fun cancelPayment() = topUpView.cancelPayment()
 
-  override fun setFinishingPurchase() = presenter.setFinishingPurchase(true)
+  override fun setFinishingPurchase(newState: Boolean) = topUpView.setFinishingPurchase(true)
 
   private fun setStoredPaymentInformation(isStored: Boolean) {
     if (isStored) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
@@ -65,7 +65,6 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
   private var cachedPaymentData: String? = null
   private var retrievedAmount = amount
   private var retrievedCurrency = currency
-  private var finishingPurchase = false
 
   fun present(savedInstanceState: Bundle?) {
     view.setupUi()
@@ -320,7 +319,6 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
       }
       paymentModel.error.hasError -> Completable.fromAction {
         if (isBillingAddressError(paymentModel.error)) {
-          finishingPurchase = false
           view.setFinishingPurchase(false)
           view.navigateToBillingAddress(retrievedAmount, retrievedCurrency)
         } else {
@@ -526,10 +524,6 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
         handleSpecificError(R.string.unknown_error)
       }
     }
-  }
-
-  fun setFinishingPurchase(newState: Boolean) {
-    finishingPurchase = newState
   }
 
   companion object {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
@@ -190,7 +190,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
         .doOnNext {
           view.showLoading()
           view.lockRotation()
-          view.setFinishingPurchase()
+          view.setFinishingPurchase(true)
         }
         .observeOn(networkScheduler)
         .flatMapSingle {
@@ -269,7 +269,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
         .doOnNext {
           view.lockRotation()
           view.hideKeyboard()
-          view.setFinishingPurchase()
+          view.setFinishingPurchase(true)
         }
         .throttleLast(2, TimeUnit.SECONDS)
         .observeOn(networkScheduler)
@@ -321,6 +321,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
       paymentModel.error.hasError -> Completable.fromAction {
         if (isBillingAddressError(paymentModel.error)) {
           finishingPurchase = false
+          view.setFinishingPurchase(false)
           view.navigateToBillingAddress(retrievedAmount, retrievedCurrency)
         } else {
           handleErrors(paymentModel, appcValue.toDouble())

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpPresenter.kt
@@ -65,6 +65,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
   private var cachedPaymentData: String? = null
   private var retrievedAmount = amount
   private var retrievedCurrency = currency
+  private var finishingPurchase = false
 
   fun present(savedInstanceState: Bundle?) {
     view.setupUi()
@@ -319,6 +320,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
       }
       paymentModel.error.hasError -> Completable.fromAction {
         if (isBillingAddressError(paymentModel.error)) {
+          finishingPurchase = false
           view.navigateToBillingAddress(retrievedAmount, retrievedCurrency)
         } else {
           handleErrors(paymentModel, appcValue.toDouble())
@@ -523,6 +525,10 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
         handleSpecificError(R.string.unknown_error)
       }
     }
+  }
+
+  fun setFinishingPurchase(newState: Boolean) {
+    finishingPurchase = newState
   }
 
   companion object {

--- a/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/adyen/AdyenTopUpView.kt
@@ -25,7 +25,7 @@ interface AdyenTopUpView {
 
   fun cancelPayment()
 
-  fun setFinishingPurchase()
+  fun setFinishingPurchase(newState: Boolean)
 
   fun finishCardConfiguration(paymentMethod: PaymentMethod, isStored: Boolean, forget: Boolean,
                               savedInstanceState: Bundle?)


### PR DESCRIPTION
**What does this PR do?**

Fix bug when pressing back from BillingAddressTopUpFragment.kt.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BillingAddressTopUpFragment.kt

**How should this be manually tested?**

Enable VPN from USA. Start a topup using credit card, insert card info and proceed to the next screen. You will be asked for Billing Address Information.
Press back and you should see the previous screen. Prior to this fix pressing back buttton would lead you to main view.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-98](https://aptoide.atlassian.net/browse/WAL-98)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass