### PR TITLE
[WAL-149] Show no bonus animation when there's no bonus on topup

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
@@ -110,7 +110,7 @@ class TopUpSuccessFragment : DaggerFragment(), TopUpSuccessFragmentView {
   }
 
   override fun show() {
-    if (bonus.isNotEmpty()) {
+    if (bonus.isNotEmpty() && bonus != "0") {
       top_up_success_animation.setAnimation(R.raw.top_up_bonus_success_animation)
       setAnimationText()
       formatBonusSuccessMessage()


### PR DESCRIPTION
**What does this PR do?**

Fixes issue where we're showing the bonus animation when there was no bonus on topup

**Database changed?**

 No

**Where should the reviewer start?**

TopUpSuccessFragment.kt

**How should this be manually tested?**

Do a topup with a partner user wallet

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/WAL-149

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass