### PR TITLE
[APPC-2222] MyAppcoins and lang parameter

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingActivity.kt
@@ -42,7 +42,8 @@ class OnboardingActivity : BaseActivity(), OnboardingView {
       intent.putExtra(SUPPORT_NOTIFICATION_CLICK, fromSupportNotification)
       return intent
     }
-
+    // NOTE - if this gets moved to myappcoins domain, don't forget to add "lang" parameter to both
+    //  these urls. See how it's done in SettingsFragment
     private const val TERMS_CONDITIONS_URL = "https://catappult.io/appcoins-wallet/terms-conditions"
     private const val PRIVACY_POLICY_URL = "https://catappult.io/appcoins-wallet/privacy-policy"
     private const val PAYMENT_METHODS_ICONS = "paymentMethodsIcons"

--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
@@ -17,6 +17,7 @@ import com.asfoundation.wallet.billing.analytics.PageViewAnalytics
 import com.asfoundation.wallet.permissions.manage.view.ManagePermissionsActivity
 import com.asfoundation.wallet.restore.RestoreWalletActivity
 import com.asfoundation.wallet.ui.settings.SettingsActivityView
+import com.asfoundation.wallet.util.getLanguageAndCountryCodes
 import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.AndroidSupportInjection
 import io.reactivex.Observable
@@ -141,7 +142,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
     redeemPreference?.setOnPreferenceClickListener {
       startBrowserActivity(Uri.parse(
           BuildConfig.MY_APPCOINS_BASE_HOST + "redeem?wallet_address=" + walletAddress +
-              "&lang=" + Locale.getDefault().language), false)
+              "&lang=" + Locale.getDefault().getLanguageAndCountryCodes()), false)
       false
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
@@ -268,6 +268,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
   override fun setPrivacyPolicyPreference() {
     val privacyPolicyPreference = findPreference<Preference>("pref_privacy_policy")
     privacyPolicyPreference?.setOnPreferenceClickListener {
+      // NOTE - if this gets moved to myappcoins domain, don't forget to add "lang" parameter
+      //  just like it is done for setRedeemCodePreference (this class)
       startBrowserActivity(Uri.parse("https://catappult.io/appcoins-wallet/privacy-policy"),
           false)
       false
@@ -277,6 +279,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
   override fun setTermsConditionsPreference() {
     val termsConditionsPreference = findPreference<Preference>("pref_terms_condition")
     termsConditionsPreference?.setOnPreferenceClickListener {
+      // NOTE - if this gets moved to myappcoins domain, don't forget to add "lang" parameter
+      //  just like it is done for setRedeemCodePreference (this class)
       startBrowserActivity(Uri.parse("https://catappult.io/appcoins-wallet/terms-conditions"),
           false)
       false

--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
@@ -23,6 +23,7 @@ import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.preference_fingerprint.*
 import kotlinx.android.synthetic.main.preference_fingerprint_off.*
+import java.util.*
 import javax.inject.Inject
 
 class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
@@ -139,8 +140,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
     val redeemPreference = findPreference<Preference>("pref_redeem")
     redeemPreference?.setOnPreferenceClickListener {
       startBrowserActivity(Uri.parse(
-          BuildConfig.MY_APPCOINS_BASE_HOST + "redeem?wallet_address=" + walletAddress),
-          false)
+          BuildConfig.MY_APPCOINS_BASE_HOST + "redeem?wallet_address=" + walletAddress +
+              "&lang=" + Locale.getDefault().language), false)
       false
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
@@ -20,6 +20,7 @@ import java.io.IOException
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
+import java.util.*
 
 /**
  *
@@ -82,6 +83,10 @@ fun HttpException.getMessage(): String {
   val message = reader?.readText()
   reader?.close()
   return if (message.isNullOrBlank()) message() else message
+}
+
+fun Locale.getLanguageAndCountryCodes(sep: String = "-"): String {
+  return this.language + sep + this.country
 }
 
 inline fun <T> Iterable<T>.sumByBigDecimal(selector: (T) -> BigDecimal): BigDecimal {


### PR DESCRIPTION
**What does this PR do?**

   Adds "lang" parameter to myappcoins page (redeem codes), to show page in language used by wallet, and not the one used by browser.
   Adds notes to other pages that will be moved to myappcoins, to remeber to add lang parameter to these

**Database changed?**

   No

**Where should the reviewer start?**

- SettingsFragment.kt

**How should this be manually tested?**

  Change the default language of the browser, to be different than the one used in the wallet app.
  Open wallet app -> Go to settings -> Redeem Code -> The myappcoins page should be displayed in the language used in wallet (if translations are available), not the one used by the browser.
  Test both on dev and prod.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2222](https://aptoide.atlassian.net/browse/APPC-2222)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)
   Answer: No.



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass