### PR TITLE
[APPC-2249] E-voucher - Implement tooltip

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
@@ -277,10 +277,11 @@ class InteractorModule {
                                   findDefaultWalletInteract: FindDefaultWalletInteract,
                                   rakamAnalytics: RakamAnalytics,
                                   userStatsLocalData: UserStatsLocalData,
-                                  gamificationMapper: GamificationMapper): PromotionsInteractor {
+                                  gamificationMapper: GamificationMapper,
+                                  preferencesRepositoryType: PreferencesRepositoryType): PromotionsInteractor {
     return PromotionsInteractor(referralInteractor, gamificationInteractor,
         promotionsRepository, findDefaultWalletInteract, userStatsLocalData, rakamAnalytics,
-        gamificationMapper)
+        gamificationMapper, preferencesRepositoryType)
   }
 
   @Provides

--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractor.kt
@@ -12,6 +12,7 @@ import com.asfoundation.wallet.interact.FindDefaultWalletInteract
 import com.asfoundation.wallet.referrals.CardNotification
 import com.asfoundation.wallet.referrals.ReferralInteractorContract
 import com.asfoundation.wallet.referrals.ReferralsScreen
+import com.asfoundation.wallet.repository.PreferencesRepositoryType
 import com.asfoundation.wallet.ui.gamification.GamificationInteractor
 import com.asfoundation.wallet.ui.gamification.GamificationMapper
 import com.asfoundation.wallet.ui.widget.holder.CardNotificationAction
@@ -27,7 +28,8 @@ class PromotionsInteractor(private val referralInteractor: ReferralInteractorCon
                            private val findWalletInteract: FindDefaultWalletInteract,
                            private val userStatsPreferencesRepository: UserStatsLocalData,
                            private val analyticsSetup: AnalyticsSetup,
-                           private val mapper: GamificationMapper) {
+                           private val mapper: GamificationMapper,
+                           private val preferencesRepositoryType: PreferencesRepositoryType) {
 
   companion object {
     const val GAMIFICATION_ID = "GAMIFICATION"
@@ -123,6 +125,9 @@ class PromotionsInteractor(private val referralInteractor: ReferralInteractorCon
 
   fun setGamificationDisclaimerShown() =
       userStatsPreferencesRepository.setGamificationDisclaimerShown()
+
+  fun setHasBeenInPromotionsScreen() =
+      preferencesRepositoryType.setHasBeenInPromotionsScreen()
 
   private fun getUnWatchedPromotion(promotionList: List<GenericResponse>): GenericResponse? {
     return promotionList.sortedByDescending { list -> list.priority }
@@ -321,4 +326,5 @@ class PromotionsInteractor(private val referralInteractor: ReferralInteractorCon
   private fun getPromotionIdKey(id: String, startDate: Long?, endDate: Long): String {
     return id + "_" + startDate + "_" + endDate
   }
+
 }

--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
@@ -22,6 +22,7 @@ class PromotionsPresenter(private val view: PromotionsView,
   private var viewState = ViewState.DEFAULT
 
   fun present() {
+    promotionsInteractor.setHasBeenInPromotionsScreen()
     handlePromotionClicks()
     handleRetryClick()
     handleBottomSheetVisibility()

--- a/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
@@ -54,4 +54,12 @@ interface PreferencesRepositoryType {
   fun increaseTimesOnHome()
 
   fun getNumberOfTimesOnHome(): Int
+
+  fun hasBeenInPromotionsScreen(): Boolean
+
+  fun setBeenInPromotionsScreen()
+
+  fun hasSeenVoucherTooltip(): Boolean
+
+  fun setHasSeenVoucherTooltip()
 }

--- a/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
@@ -49,7 +49,7 @@ interface PreferencesRepositoryType {
 
   fun hasBeenInSettings(): Boolean
 
-  fun setBeenInSettings()
+  fun setHasBeenInSettings()
 
   fun increaseTimesOnHome()
 
@@ -57,7 +57,7 @@ interface PreferencesRepositoryType {
 
   fun hasBeenInPromotionsScreen(): Boolean
 
-  fun setBeenInPromotionsScreen()
+  fun setHasBeenInPromotionsScreen()
 
   fun hasSeenVoucherTooltip(): Boolean
 

--- a/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
@@ -125,7 +125,7 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
 
   override fun hasBeenInSettings(): Boolean = pref.getBoolean(HAS_BEEN_IN_SETTINGS, false)
 
-  override fun setBeenInSettings() {
+  override fun setHasBeenInSettings() {
     pref.edit()
         .putBoolean(HAS_BEEN_IN_SETTINGS, true)
         .apply()
@@ -142,7 +142,7 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
   override fun hasBeenInPromotionsScreen(): Boolean =
       pref.getBoolean(HAS_BEEN_IN_PROMOTIONS_SCREEN, false)
 
-  override fun setBeenInPromotionsScreen() {
+  override fun setHasBeenInPromotionsScreen() {
     pref.edit()
         .putBoolean(HAS_BEEN_IN_PROMOTIONS_SCREEN, true)
         .apply()

--- a/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
@@ -14,6 +14,7 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
 
     //String was kept the same for legacy purposes
     private const val HAS_SEEN_PROMOTION_TOOLTIP = "first_time_on_transaction_activity"
+    private const val HAS_BEEN_IN_PROMOTIONS_SCREEN = "has_been_in_promotions_screen"
     private const val AUTO_UPDATE_VERSION = "auto_update_version"
     private const val POA_LIMIT_SEEN_TIME = "poa_limit_seen_time"
     private const val UPDATE_SEEN_TIME = "update_seen_time"
@@ -22,6 +23,7 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
     private const val WALLET_ID = "wallet_id"
     private const val HAS_BEEN_IN_SETTINGS = "has_been_in_settings"
     private const val NUMBER_OF_TIMES_IN_HOME = "number_of_times_in_home"
+    private const val HAS_SEEN_VOUCHER_TOOLTIP = "has_seen_voucher_tooltip"
   }
 
   override fun hasCompletedOnboarding() = pref.getBoolean(ONBOARDING_COMPLETE_KEY, false)
@@ -50,9 +52,8 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
         .apply()
   }
 
-  override fun hasSeenPromotionTooltip(): Boolean {
-    return pref.getBoolean(HAS_SEEN_PROMOTION_TOOLTIP, false)
-  }
+  override fun hasSeenPromotionTooltip(): Boolean =
+      pref.getBoolean(HAS_SEEN_PROMOTION_TOOLTIP, false)
 
   override fun setHasSeenPromotionTooltip() {
     pref.edit()
@@ -137,4 +138,21 @@ class SharedPreferencesRepository(private val pref: SharedPreferences) : Prefere
   }
 
   override fun getNumberOfTimesOnHome(): Int = pref.getInt(NUMBER_OF_TIMES_IN_HOME, 0)
+
+  override fun hasBeenInPromotionsScreen(): Boolean =
+      pref.getBoolean(HAS_BEEN_IN_PROMOTIONS_SCREEN, false)
+
+  override fun setBeenInPromotionsScreen() {
+    pref.edit()
+        .putBoolean(HAS_BEEN_IN_PROMOTIONS_SCREEN, true)
+        .apply()
+  }
+
+  override fun hasSeenVoucherTooltip(): Boolean = pref.getBoolean(HAS_SEEN_VOUCHER_TOOLTIP, false)
+
+  override fun setHasSeenVoucherTooltip() {
+    pref.edit()
+        .putBoolean(HAS_SEEN_VOUCHER_TOOLTIP, true)
+        .apply()
+  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
@@ -191,7 +191,9 @@ public class TransactionsActivity extends BaseNavigationActivity implements View
     viewModel.shareApp()
         .observe(this, this::shareApp);
     viewModel.shouldShowPromotionsTooltip()
-        .observe(this, this::showPromotionsOverlay);
+        .observe(this, this::showAllPromotionsOverlay);
+    viewModel.shouldShowVouchersTooltip()
+        .observe(this, this::showVouchersOverlay);
     viewModel.balanceWalletsExperimentAssignment()
         .observe(this, this::changeBottomNavigationName);
     viewModel.shouldShowRateUsDialog()
@@ -565,17 +567,25 @@ public class TransactionsActivity extends BaseNavigationActivity implements View
     viewModel.navigateToPromotions(this);
   }
 
-  private void showPromotionsOverlay(Boolean shouldShow) {
+  private void showAllPromotionsOverlay(Boolean shouldShow) {
+    showOverlay(shouldShow, OverlayType.ALL_PROMOTIONS);
+  }
+
+  private void showVouchersOverlay(Boolean shouldShow) {
+    showOverlay(shouldShow, OverlayType.VOUCHERS);
+  }
+
+  // todo analyze what changes are needed here (showPromotionsOverlay was something else)
+  private void showOverlay(Boolean shouldShow, OverlayType type) {
     if (shouldShow) {
       getSupportFragmentManager().beginTransaction()
           .setCustomAnimations(R.anim.fragment_fade_in_animation,
               R.anim.fragment_fade_out_animation, R.anim.fragment_fade_in_animation,
               R.anim.fragment_fade_out_animation)
-          .add(R.id.container,
-              OverlayFragment.newInstance(PROMOTIONS.getPosition(), OverlayType.ALL_PROMOTIONS))
+          .add(R.id.container, OverlayFragment.newInstance(PROMOTIONS.getPosition(), type))
           .addToBackStack(OverlayFragment.class.getName())
           .commit();
-      viewModel.onPromotionsShown();
+      viewModel.onPromotionsShown(type);
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
@@ -37,6 +37,7 @@ import com.asfoundation.wallet.referrals.CardNotification;
 import com.asfoundation.wallet.transactions.Transaction;
 import com.asfoundation.wallet.ui.appcoins.applications.AppcoinsApplication;
 import com.asfoundation.wallet.ui.overlay.OverlayFragment;
+import com.asfoundation.wallet.ui.overlay.OverlayType;
 import com.asfoundation.wallet.ui.toolbar.ToolbarArcBackground;
 import com.asfoundation.wallet.ui.widget.adapter.TransactionsAdapter;
 import com.asfoundation.wallet.ui.widget.entity.TransactionsModel;
@@ -570,7 +571,8 @@ public class TransactionsActivity extends BaseNavigationActivity implements View
           .setCustomAnimations(R.anim.fragment_fade_in_animation,
               R.anim.fragment_fade_out_animation, R.anim.fragment_fade_in_animation,
               R.anim.fragment_fade_out_animation)
-          .add(R.id.container, OverlayFragment.newInstance(PROMOTIONS.getPosition()))
+          .add(R.id.container,
+              OverlayFragment.newInstance(PROMOTIONS.getPosition(), OverlayType.ALL_PROMOTIONS))
           .addToBackStack(OverlayFragment.class.getName())
           .commit();
       viewModel.onPromotionsShown();

--- a/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
@@ -575,7 +575,6 @@ public class TransactionsActivity extends BaseNavigationActivity implements View
     showOverlay(shouldShow, OverlayType.VOUCHERS);
   }
 
-  // todo analyze what changes are needed here (showPromotionsOverlay was something else)
   private void showOverlay(Boolean shouldShow, OverlayType type) {
     if (shouldShow) {
       getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayData.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayData.kt
@@ -1,0 +1,3 @@
+package com.asfoundation.wallet.ui.overlay
+
+data class OverlayData(val bottomNavigationItem: Int, val type: OverlayType)

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayInteractor.kt
@@ -5,4 +5,6 @@ import com.asfoundation.wallet.repository.PreferencesRepositoryType
 class OverlayInteractor(private val preferencesRepositoryType: PreferencesRepositoryType) {
 
   fun setHasSeenPromotionTooltip() = preferencesRepositoryType.setHasSeenPromotionTooltip()
+
+  fun setHasSeenVoucherTooltip() = preferencesRepositoryType.setHasSeenVoucherTooltip()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayModule.kt
@@ -1,12 +1,9 @@
 package com.asfoundation.wallet.ui.overlay
 
 import com.asfoundation.wallet.repository.PreferencesRepositoryType
-import com.asfoundation.wallet.ui.iab.payments.carrier.verify.CarrierVerifyData
-import com.asfoundation.wallet.ui.iab.payments.carrier.verify.CarrierVerifyFragment
 import dagger.Module
 import dagger.Provides
 import io.reactivex.disposables.CompositeDisposable
-import java.math.BigDecimal
 
 @Module
 class OverlayModule {

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayModule.kt
@@ -1,17 +1,29 @@
 package com.asfoundation.wallet.ui.overlay
 
 import com.asfoundation.wallet.repository.PreferencesRepositoryType
+import com.asfoundation.wallet.ui.iab.payments.carrier.verify.CarrierVerifyData
+import com.asfoundation.wallet.ui.iab.payments.carrier.verify.CarrierVerifyFragment
 import dagger.Module
 import dagger.Provides
 import io.reactivex.disposables.CompositeDisposable
+import java.math.BigDecimal
 
 @Module
 class OverlayModule {
 
   @Provides
+  fun providesOverlayData(fragment: OverlayFragment): OverlayData {
+    fragment.arguments!!.apply {
+      return OverlayData(getInt(OverlayFragment.BOTTOM_NAVIGATION_ITEM_KEY),
+          getSerializable(OverlayFragment.OVERLAY_TYPE_KEY) as OverlayType)
+    }
+  }
+
+  @Provides
   fun providesOverlayPresenter(fragment: OverlayFragment,
+                               data: OverlayData,
                                interactor: OverlayInteractor): OverlayPresenter {
-    return OverlayPresenter(fragment as OverlayView, interactor, CompositeDisposable())
+    return OverlayPresenter(fragment as OverlayView, data, interactor, CompositeDisposable())
   }
 
   @Provides

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayPresenter.kt
@@ -37,7 +37,7 @@ class OverlayPresenter(private val view: OverlayView,
   }
 
   private fun setHasSeenTooltip() {
-    when(data.type) {
+    when (data.type) {
       OverlayType.ALL_PROMOTIONS -> interactor.setHasSeenPromotionTooltip()
       OverlayType.VOUCHERS -> interactor.setHasSeenVoucherTooltip()
     }

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayPresenter.kt
@@ -4,18 +4,24 @@ import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 
 class OverlayPresenter(private val view: OverlayView,
+                       private val data: OverlayData,
                        private val interactor: OverlayInteractor,
                        private val disposable: CompositeDisposable) {
 
   fun present() {
+    initializeView()
     handleDismissClick()
     handleDiscoverClick()
+  }
+
+  private fun initializeView() {
+    view.initializeView(data.bottomNavigationItem, data.type)
   }
 
   private fun handleDiscoverClick() {
     disposable.add(view.discoverClick()
         .doOnNext {
-          interactor.setHasSeenPromotionTooltip()
+          setHasSeenTooltip()
           view.navigateToPromotions()
         }
         .subscribe({}, { it.printStackTrace() }))
@@ -24,10 +30,17 @@ class OverlayPresenter(private val view: OverlayView,
   private fun handleDismissClick() {
     disposable.add(Observable.merge(view.dismissClick(), view.overlayClick())
         .doOnNext {
-          interactor.setHasSeenPromotionTooltip()
+          setHasSeenTooltip()
           view.dismissView()
         }
         .subscribe({}, { it.printStackTrace() }))
+  }
+
+  private fun setHasSeenTooltip() {
+    when(data.type) {
+      OverlayType.ALL_PROMOTIONS -> interactor.setHasSeenPromotionTooltip()
+      OverlayType.VOUCHERS -> interactor.setHasSeenVoucherTooltip()
+    }
   }
 
   fun stop() = disposable.clear()

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayType.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayType.kt
@@ -1,0 +1,5 @@
+package com.asfoundation.wallet.ui.overlay
+
+enum class OverlayType {
+  ALL_PROMOTIONS, VOUCHERS
+}

--- a/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/overlay/OverlayView.kt
@@ -4,6 +4,8 @@ import io.reactivex.Observable
 
 interface OverlayView {
 
+  fun initializeView(bottomNavigationItem: Int, type: OverlayType)
+
   fun discoverClick(): Observable<Any>
 
   fun dismissClick(): Observable<Any>

--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsInteractor.kt
@@ -52,5 +52,5 @@ class SettingsInteractor(private val findDefaultWalletInteract: FindDefaultWalle
 
   fun hasAuthenticationPermission() = fingerprintPreferences.hasAuthenticationPermission()
 
-  fun setHasBeenInSettings() = preferenceRepository.setBeenInSettings()
+  fun setHasBeenInSettings() = preferenceRepository.setHasBeenInSettings()
 }


### PR DESCRIPTION
**What does this PR do?**

   Implements displaying of tooltip highlighting new vouchers feature. The tooltip is always shown after the promotions tooltip, and for new installs, before fingerprint tooltip.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TransactionsInteractor.java (~ line 111)

**How should this be manually tested?**

  Here is a list of use cases that you can test, individually:
- Fresh install. Open app. Promotions tooltip -> Dismiss. Close app and reopen. E-vouchers tooltip -> Dismiss / Discover. Close app and reopen. Fingerprint tooltip.
- Fresh install. Open app. Promotions tooltip -> Discover. Close app and reopen. E-vouchers tooltip not shown because user has already gone to promotions screen. Close app and reopen. Fingerprint Notification.
- Update from a version without e-vouchers tooltip, where Promotions and Fingerprint tooltips have been shown. E-vouchers tooltip should be shown when opening 1st time after update.
- Update from a version without e-vouchers tooltip, where only Promotions tooltip was shown. Opening the app should reveal e-vouchers tooltip. Closing then reopening will reveal fingerprint tooltip.
- Update from a version without e-vouchers tooltip, where no tooltips have been shown (app hasn't been opened on home screen yet). Should behave as fresh install.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2249](https://aptoide.atlassian.net/browse/APPC-2249)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)
   Answer: No.



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass