### PR TITLE
[APPC-2301] Empty bonus for partners users from pre selected

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
@@ -466,6 +466,7 @@ class PaymentMethodsFragment : DaggerFragment(), PaymentMethodsView {
 
   override fun showBonus() {
     bonus_view.visibility = View.VISIBLE
+    bonus_view.setPurchaseBonusDescription(getString(R.string.gamification_purchase_body))
     bonus_view.showPurchaseBonusHeader()
     bottom_separator?.visibility = View.VISIBLE
     bonus_view.hideSkeleton()
@@ -486,7 +487,8 @@ class PaymentMethodsFragment : DaggerFragment(), PaymentMethodsView {
   }
 
   override fun replaceBonus() {
-    bonus_view.visibility = View.INVISIBLE
+    bonus_view.visibility = View.VISIBLE
+    bottom_separator?.visibility = View.VISIBLE
     bonus_view.setPurchaseBonusDescription(getString(R.string.purchase_poa_body))
     bonus_view.hidePurchaseBonusHeader()
     bonus_view.hideSkeleton()
@@ -593,7 +595,6 @@ class PaymentMethodsFragment : DaggerFragment(), PaymentMethodsView {
     fiat_price_skeleton.visibility = View.GONE
     appc_price_skeleton.visibility = View.GONE
     payments_skeleton.visibility = View.GONE
-    bonus_view.hideSkeleton()
   }
 
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -79,6 +79,8 @@ class PaymentMethodsPresenter(
         .doOnNext { selectedPaymentMethod ->
           if (interactor.isBonusActiveAndValid()) {
             handleBonusVisibility(selectedPaymentMethod)
+          } else {
+            view.removeBonus()
           }
           handlePositiveButtonText(selectedPaymentMethod)
         }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/common/PurchaseBonusView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/common/PurchaseBonusView.kt
@@ -48,7 +48,7 @@ class PurchaseBonusView : FrameLayout {
 
   fun hidePurchaseBonusHeader() {
     showHeader = false
-    bonus_layout.visibility = View.GONE
+    bonus_layout.visibility = View.INVISIBLE
   }
 
   fun showPurchaseBonusHeader() {
@@ -57,7 +57,9 @@ class PurchaseBonusView : FrameLayout {
   }
 
   fun setPurchaseBonusDescription(description: String) {
-    bonus_msg.visibility = View.GONE
+    bonus_msg.text = description
+    bonus_msg.visibility = View.VISIBLE
+    bonus_layout.visibility = View.INVISIBLE
   }
 
   fun showSkeleton() {


### PR DESCRIPTION
**What does this PR do?**

Fixes 2 bugs related to bonus view:
- Bonus message was appearing with % to partner users after they had some pre selected methods (described in ticket)
- Bonus visibility switch when switching between earn appc and other payment methods.

**Database changed?**

No

**Where should the reviewer start?**

PaymentMethodsPresenter.kt
PurchaseBonusView.kt

**How should this be manually tested?**

With a partner user, make a purchase with APPC-C, then after it's preselected, click on other payment methods and check if the bonus message doesn't appear.
The other fix, requires changing the code, since at the moment the "Earn appcoins" method doesn't appear. But to test change on the handleBonusVisiblity the EARN_APPC for CREDIT_CARD, this way Credit card method behaves just like earn appcoins. Check if it has the expected behaviour (show only "try for 2 minutes...", when earn appc is selected and the usual for the other methods) 

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-2301

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass