### PR TITLE
[bugfix/APPC-2383] Fix for no network screen after rotating verify screen

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/verification/intro/VerificationIntroPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/verification/intro/VerificationIntroPresenter.kt
@@ -47,7 +47,6 @@ class VerificationIntroPresenter(private val view: VerificationIntroView,
     if (currentError == null) loadModel(savedInstanceState)
     else {
       when {
-        currentError?.noNetworkError == true -> view.showNetworkError()
         currentError?.errorType != null -> view.showError(currentError!!.errorType)
         currentError?.errorString != null -> view.showSpecificError(currentError!!.errorString!!)
         else -> loadModel(savedInstanceState)


### PR DESCRIPTION
**What does this PR do?**

   Fixes issue where rotating the screen on VerifyIntroFragment after a no network error was shown was not not loading correctly after rotating back.

**Database changed?**

   No

**How should this be manually tested?**
   Go to an unverified wallet, go to verify, turn off WiFi and rotate the screen. A no network error should appear. Then, turn on WiFi back again and rotate the screen. It should now load normally.
  
**What are the relevant tickets?**

  [APPC-2383](https://aptoide.atlassian.net/browse/APPC-2383)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass