### PR TITLE
[APPC-2365] Expire field rename. GRACE and HOLD status added

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionItem.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionItem.kt
@@ -5,19 +5,22 @@ import java.io.Serializable
 import java.math.BigDecimal
 import java.util.*
 
-data class SubscriptionItem(val itemName: String, val period: Period?, val status: Status,
-                            val started: Date?, val renewal: Date?, val expire: Date?,
-                            val ended: Date?, val packageName: String, val appName: String,
-                            val appIcon: String, val fiatAmount: BigDecimal, val fiatSymbol: String,
-                            val currency: String, val paymentMethod: String,
-                            val paymentIcon: String, val appcAmount: BigDecimal,
-                            val appcLabel: String, val uid: String) : Serializable {
+data class SubscriptionItem(
+    val itemName: String, val period: Period?, val status: Status,
+    val started: Date?, val renewal: Date?, val expiry: Date?,
+    val ended: Date?, val packageName: String, val appName: String,
+    val appIcon: String, val fiatAmount: BigDecimal, val fiatSymbol: String,
+    val currency: String, val paymentMethod: String,
+    val paymentIcon: String, val appcAmount: BigDecimal,
+    val appcLabel: String, val uid: String
+) : Serializable {
 
   fun isActiveSubscription(): Boolean {
-    return status == Status.ACTIVE || status == Status.CANCELED || status == Status.PAUSED
+    return status == Status.ACTIVE || status == Status.CANCELED || status == Status.PAUSED ||
+        status == Status.GRACE
   }
 }
 
 enum class Status {
-  ACTIVE, CANCELED, EXPIRED, PAUSED, PENDING, REVOKED
+  ACTIVE, CANCELED, EXPIRED, PAUSED, PENDING, REVOKED, GRACE, HOLD
 }

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionItem.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionItem.kt
@@ -5,15 +5,13 @@ import java.io.Serializable
 import java.math.BigDecimal
 import java.util.*
 
-data class SubscriptionItem(
-    val itemName: String, val period: Period?, val status: Status,
-    val started: Date?, val renewal: Date?, val expiry: Date?,
-    val ended: Date?, val packageName: String, val appName: String,
-    val appIcon: String, val fiatAmount: BigDecimal, val fiatSymbol: String,
-    val currency: String, val paymentMethod: String,
-    val paymentIcon: String, val appcAmount: BigDecimal,
-    val appcLabel: String, val uid: String
-) : Serializable {
+data class SubscriptionItem(val itemName: String, val period: Period?, val status: Status,
+                            val started: Date?, val renewal: Date?, val expiry: Date?,
+                            val ended: Date?, val packageName: String, val appName: String,
+                            val appIcon: String, val fiatAmount: BigDecimal, val fiatSymbol: String,
+                            val currency: String, val paymentMethod: String,
+                            val paymentIcon: String, val appcAmount: BigDecimal,
+                            val appcLabel: String, val uid: String) : Serializable {
 
   fun isActiveSubscription(): Boolean {
     return status == Status.ACTIVE || status == Status.CANCELED || status == Status.PAUSED ||

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionViewHolder.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/SubscriptionViewHolder.kt
@@ -61,7 +61,7 @@ class SubscriptionViewHolder(itemView: View, private val currencyFormatUtils: Cu
 
     val dateFormat = SimpleDateFormat("MMM yy", Locale.getDefault())
 
-    item.expire?.let {
+    item.expiry?.let {
       view.expires_on.text = view.context.getString(R.string.subscriptions_expiration_body,
           dateFormat.format(it))
     }

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsLocalData.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsLocalData.kt
@@ -50,7 +50,7 @@ class UserSubscriptionsLocalData(private val userSubscriptionsDao: UserSubscript
       val method = order.method
       val appc = order.appc
       val entity = UserSubscriptionEntity(response.uid, walletAddress, response.sku, response.title,
-          response.period, response.subStatus, response.started, response.renewal, response.expire,
+          response.period, response.subStatus, response.started, response.renewal, response.expiry,
           response.ended, application.name, application.title, application.icon, order.gateway,
           order.reference, order.value, order.label, order.currency, order.symbol, order.created,
           method.name, method.title, method.logo, appc.value, appc.label)

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapper.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapper.kt
@@ -20,7 +20,7 @@ class UserSubscriptionsMapper {
       val application = it.application
       val order = it.order
       SubscriptionItem(it.title, mapPeriod(it.period), mapStatus(it.subStatus),
-          mapDate(it.started), mapDate(it.renewal), mapDate(it.expire), mapDate(it.ended),
+          mapDate(it.started), mapDate(it.renewal), mapDate(it.expiry), mapDate(it.ended),
           application.name, application.title, application.icon, order.value, order.symbol,
           order.currency, order.method.title, order.method.logo, order.appc.value,
           order.appc.label, it.uid)
@@ -43,6 +43,8 @@ class UserSubscriptionsMapper {
       SubscriptionSubStatus.PAUSED -> Status.PAUSED
       SubscriptionSubStatus.PENDING -> Status.PENDING
       SubscriptionSubStatus.REVOKED -> Status.REVOKED
+      SubscriptionSubStatus.GRACE -> Status.GRACE
+      SubscriptionSubStatus.HOLD -> Status.HOLD
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/cancel/SubscriptionCancelPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/cancel/SubscriptionCancelPresenter.kt
@@ -29,7 +29,7 @@ class SubscriptionCancelPresenter(private val view: SubscriptionCancelView,
   }
 
   private fun canCancelSubscription(status: Status): Boolean {
-    return status == Status.ACTIVE || status == Status.PAUSED
+    return status == Status.ACTIVE || status == Status.PAUSED || status == Status.GRACE
   }
 
   private fun onError(throwable: Throwable) {

--- a/app/src/main/java/com/asfoundation/wallet/subscriptions/details/SubscriptionDetailsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/subscriptions/details/SubscriptionDetailsFragment.kt
@@ -122,7 +122,7 @@ class SubscriptionDetailsFragment : DaggerFragment(), SubscriptionDetailsView {
 
     val dateFormat = SimpleDateFormat("MMM yy", Locale.getDefault())
 
-    subscriptionItem.expire?.let {
+    subscriptionItem.expiry?.let {
       expires_on.text = getString(R.string.subscriptions_details_cancelled_body,
           dateFormat.format(it))
     }

--- a/app/src/test/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapperTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapperTest.kt
@@ -79,8 +79,8 @@ class UserSubscriptionsMapperTest {
         SubscriptionSubStatus.GRACE, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
         applicationResponse, orderResponse)
     val responseHold = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
-        SubscriptionSubStatus.HOLD, TEST_STARTED, null, null, null, applicationResponse,
-        orderResponse)
+        SubscriptionSubStatus.HOLD, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
+        applicationResponse, orderResponse)
     val allSubscriptions = UserSubscriptionsListResponse(
         listOf(activeSubResponse, expiredSubResponse, responseCanceled, responsePaused,
             responseRevoked, responsePending, responseGrace, responseHold))
@@ -121,10 +121,10 @@ class UserSubscriptionsMapperTest {
             TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
             TEST_APPC_LABEL, TEST_UID)
     val onHoldItem =
-        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.HOLD, expectedDate, null, null,
-            null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL,
-            TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL,
-            TEST_UID)
+        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.HOLD, expectedDate, expectedDate,
+            expectedDate, null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT,
+            TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
+            TEST_APPC_LABEL, TEST_UID)
     val allItemsList = listOf(activeItem, expiredItem, canceledItem, pausedItem, revokedItem,
         pendingItem, gracePeriodItem, onHoldItem)
     val expiredItemList = listOf(expiredItem)

--- a/app/src/test/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapperTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/subscriptions/UserSubscriptionsMapperTest.kt
@@ -54,67 +54,79 @@ class UserSubscriptionsMapperTest {
         UserSubscriptionsMapper.LOCALE)
     val expectedDate = dateFormat.parse(TEST_STARTED)
     val applicationResponse = ApplicationInfoResponse(TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON)
-    val orderResponse =
-        OrderResponse(TEST_GATEWAY, TEST_REFERENCE, TEST_FIAT_AMOUNT, TEST_LABEL, TEST_CURRENCY,
-            TEST_SYMBOL, TEST_CREATED,
-            MethodResponse(TEST_PAYMENT_METHOD, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON),
-            AppcPrice(TEST_APPC_AMOUNT, TEST_APPC_LABEL))
-    val activeSubResponse =
-        UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
-            SubscriptionSubStatus.ACTIVE, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
-            applicationResponse, orderResponse)
-    val expiredSubResponse =
-        UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
-            SubscriptionSubStatus.EXPIRED, TEST_STARTED, TEST_RENEWAL, null, TEST_ENDED,
-            applicationResponse, orderResponse)
+    val orderResponse = OrderResponse(TEST_GATEWAY, TEST_REFERENCE, TEST_FIAT_AMOUNT, TEST_LABEL,
+        TEST_CURRENCY, TEST_SYMBOL, TEST_CREATED,
+        MethodResponse(TEST_PAYMENT_METHOD, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON),
+        AppcPrice(TEST_APPC_AMOUNT, TEST_APPC_LABEL))
+    val activeSubResponse = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
+        SubscriptionSubStatus.ACTIVE, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
+        applicationResponse, orderResponse)
+    val expiredSubResponse = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
+        SubscriptionSubStatus.EXPIRED, TEST_STARTED, TEST_RENEWAL, null, TEST_ENDED,
+        applicationResponse, orderResponse)
     val responseCanceled = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
         SubscriptionSubStatus.CANCELED, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
         applicationResponse, orderResponse)
     val responsePaused = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
-        SubscriptionSubStatus.PAUSED, TEST_STARTED, null, null, null,
-        applicationResponse, orderResponse)
+        SubscriptionSubStatus.PAUSED, TEST_STARTED, null, null, null, applicationResponse,
+        orderResponse)
     val responseRevoked = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
         SubscriptionSubStatus.REVOKED, TEST_STARTED, null, TEST_EXPIRE, TEST_ENDED,
         applicationResponse, orderResponse)
     val responsePending = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
-        SubscriptionSubStatus.PENDING, null, null, null, null,
+        SubscriptionSubStatus.PENDING, null, null, null, null, applicationResponse, orderResponse)
+    val responseGrace = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
+        SubscriptionSubStatus.GRACE, TEST_STARTED, TEST_RENEWAL, TEST_EXPIRE, null,
         applicationResponse, orderResponse)
+    val responseHold = UserSubscriptionResponse(TEST_UID, TEST_SKU, TEST_TITLE, TEST_PERIOD,
+        SubscriptionSubStatus.HOLD, TEST_STARTED, null, null, null, applicationResponse,
+        orderResponse)
     val allSubscriptions = UserSubscriptionsListResponse(
         listOf(activeSubResponse, expiredSubResponse, responseCanceled, responsePaused,
-            responseRevoked, responsePending))
+            responseRevoked, responsePending, responseGrace, responseHold))
     val expiredSubscriptions = UserSubscriptionsListResponse(listOf(expiredSubResponse))
     val model = mapper.mapToSubscriptionModel(allSubscriptions, expiredSubscriptions, true)
     val activeItem =
-        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.ACTIVE, expectedDate,
-            expectedDate, expectedDate, null, TEST_PACKAGE_NAME, TEST_TITLE,
-            TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE,
-            TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
+        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.ACTIVE, expectedDate, expectedDate,
+            expectedDate, null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT,
+            TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
+            TEST_APPC_LABEL, TEST_UID)
     val expiredItem =
-        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.EXPIRED, expectedDate,
-            expectedDate, null, expectedDate, TEST_PACKAGE_NAME, TEST_TITLE,
-            TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE,
-            TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
+        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.EXPIRED, expectedDate, expectedDate,
+            null, expectedDate, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT,
+            TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
+            TEST_APPC_LABEL, TEST_UID)
     val canceledItem =
         SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.CANCELED, expectedDate,
-            expectedDate, expectedDate, null,
-            TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY,
-            TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
+            expectedDate, expectedDate, null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON,
+            TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON,
+            TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
     val pausedItem =
         SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.PAUSED, expectedDate, null, null,
-            null,
-            TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY,
-            TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
+            null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL,
+            TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL,
+            TEST_UID)
     val revokedItem =
         SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.REVOKED, expectedDate, null,
-            expectedDate, expectedDate,
-            TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY,
-            TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
+            expectedDate, expectedDate, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT,
+            TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
+            TEST_APPC_LABEL, TEST_UID)
     val pendingItem =
         SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.PENDING, null, null, null, null,
             TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL, TEST_CURRENCY,
             TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL, TEST_UID)
-    val allItemsList =
-        listOf(activeItem, expiredItem, canceledItem, pausedItem, revokedItem, pendingItem)
+    val gracePeriodItem =
+        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.GRACE, expectedDate, expectedDate,
+            expectedDate, null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT,
+            TEST_SYMBOL, TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT,
+            TEST_APPC_LABEL, TEST_UID)
+    val onHoldItem =
+        SubscriptionItem(TEST_TITLE, Period(0, 0, 1, 0), Status.HOLD, expectedDate, null, null,
+            null, TEST_PACKAGE_NAME, TEST_TITLE, TEST_ICON, TEST_FIAT_AMOUNT, TEST_SYMBOL,
+            TEST_CURRENCY, TEST_PAYMENT_TITLE, TEST_PAYMENT_ICON, TEST_APPC_AMOUNT, TEST_APPC_LABEL,
+            TEST_UID)
+    val allItemsList = listOf(activeItem, expiredItem, canceledItem, pausedItem, revokedItem,
+        pendingItem, gracePeriodItem, onHoldItem)
     val expiredItemList = listOf(expiredItem)
     val expectedModel = SubscriptionModel(allItemsList, expiredItemList, true)
     Assert.assertEquals(expectedModel.toString(), model.toString())

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/subscriptions/UserSubscriptionResponse.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/subscriptions/UserSubscriptionResponse.kt
@@ -5,23 +5,23 @@ import com.appcoins.wallet.bdsbilling.subscriptions.OrderResponse
 import com.google.gson.annotations.SerializedName
 
 /**
- * Object of a subcription to be shown on app for the user to manage
+ * Object of a subscription to be shown on app for the user to manage
  * @param period Period of subscription, example "P1M"
  * @param title Name of the sku
  * @param subStatus Status of the subscription
  * @param started Date when subscription started, null when subStatus is PENDING
  * @param renewal Date when subscription is renewed, null when subStatus is PENDING, PAUSED, EXPIRED or REVOKED
- * @param expire Date when subscription will expire or has expired, null when subStatus is PENDING or PAUSED
- * @param ended Date when subscription ended, null when substatus is PENDING, ACTIVE, CANCELED or PAUSED
+ * @param expiry Date when subscription will expire or has expired, null when subStatus is PENDING or PAUSED
+ * @param ended Date when subscription ended, null when subStatus is PENDING, ACTIVE, CANCELED or PAUSED
  *
  */
 data class UserSubscriptionResponse(val uid: String, val sku: String, val title: String,
                                     val period: String, @SerializedName("substatus")
                                     val subStatus: SubscriptionSubStatus, val started: String?,
-                                    val renewal: String?, val expire: String?, val ended: String?,
+                                    val renewal: String?, val expiry: String?, val ended: String?,
                                     val application: ApplicationInfoResponse,
                                     val order: OrderResponse)
 
 enum class SubscriptionSubStatus {
-  ACTIVE, PENDING, PAUSED, CANCELED, EXPIRED, REVOKED
+  PENDING, ACTIVE, PAUSED, GRACE, HOLD, CANCELED, EXPIRED, REVOKED
 }

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/subscriptions/UserSubscriptionResponse.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/subscriptions/UserSubscriptionResponse.kt
@@ -12,7 +12,7 @@ import com.google.gson.annotations.SerializedName
  * @param started Date when subscription started, null when subStatus is PENDING
  * @param renewal Date when subscription is renewed, null when subStatus is PENDING, PAUSED, EXPIRED or REVOKED
  * @param expiry Date when subscription will expire or has expired, null when subStatus is PENDING or PAUSED
- * @param ended Date when subscription ended, null when subStatus is PENDING, ACTIVE, CANCELED or PAUSED
+ * @param ended Date when subscription ended, null when subStatus is PENDING, ACTIVE, GRACE, HOLD, CANCELED or PAUSED
  *
  */
 data class UserSubscriptionResponse(val uid: String, val sku: String, val title: String,


### PR DESCRIPTION
Includes fixing of unit tests to consider this.
This does not include any UI / updates.

**What does this PR do?**

   Supporting new states (GRACE and HOLD) for subscriptions. Updated field name to be consistent with API.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] UserSubscriptionsResponse.kt

**How should this be manually tested?**

   For the new field name, test with a wallet that has an expired subscription (e.g. cancelled and expiration date has been reached). Without this PR, the wallet would crash (because field name is outdated).
   For the new states, you can manually add code to see if GRACE subscriptions appear as active (HOLD should not). Other than that, there's not much that can be tested I think. You should, however, run the updated unit tests on `UserSubscriptionsMapper`

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2365](https://aptoide.atlassian.net/browse/APPC-2365)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

   _Answer:_ No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass