### PR TITLE
[APPC-2407] [Perks] Only 1 Perk is shown with WiFi off

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
@@ -28,6 +28,7 @@ import com.appcoins.wallet.gamification.Gamification
 import com.appcoins.wallet.gamification.repository.PromotionDatabase
 import com.appcoins.wallet.gamification.repository.PromotionDatabase.Companion.MIGRATION_1_2
 import com.appcoins.wallet.gamification.repository.PromotionDatabase.Companion.MIGRATION_2_3
+import com.appcoins.wallet.gamification.repository.PromotionDatabase.Companion.MIGRATION_3_4
 import com.appcoins.wallet.gamification.repository.PromotionsRepository
 import com.appcoins.wallet.gamification.repository.WalletOriginDao
 import com.appcoins.wallet.permissions.Permissions
@@ -376,6 +377,7 @@ internal class AppModule {
     return Room.databaseBuilder(context, PromotionDatabase::class.java, "promotion_database")
         .addMigrations(MIGRATION_1_2)
         .addMigrations(MIGRATION_2_3)
+        .addMigrations(MIGRATION_3_4)
         .build()
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/rating/RatingInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/rating/RatingInteractor.kt
@@ -6,6 +6,7 @@ import com.asfoundation.wallet.ui.gamification.GamificationInteractor
 import io.reactivex.Completable
 import io.reactivex.Scheduler
 import io.reactivex.Single
+import java.util.*
 
 class RatingInteractor(private val ratingRepository: RatingRepository,
                        private val gamificationInteractor: GamificationInteractor,
@@ -45,7 +46,9 @@ class RatingInteractor(private val ratingRepository: RatingRepository,
 
   fun sendUserFeedback(feedbackText: String): Completable {
     return walletService.getWalletAddress()
-        .flatMap { address -> ratingRepository.sendFeedback(address, feedbackText) }
+        .flatMap { address ->
+          ratingRepository.sendFeedback(address.toLowerCase(Locale.ROOT), feedbackText)
+        }
         .ignoreElement()
         .subscribeOn(ioScheduler)
   }

--- a/app/src/main/java/com/asfoundation/wallet/support/SupportInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/support/SupportInteractor.kt
@@ -33,7 +33,7 @@ class SupportInteractor(private val supportRepository: SupportRepository,
 
   fun showSupport(walletAddress: String, gamificationLevel: Int): Completable {
     return Completable.fromAction {
-      registerUser(gamificationLevel, walletAddress.toLowerCase(Locale.ROOT))
+      registerUser(gamificationLevel, walletAddress)
       displayChatScreen()
     }
   }
@@ -60,13 +60,16 @@ class SupportInteractor(private val supportRepository: SupportRepository,
   }
 
   fun registerUser(level: Int, walletAddress: String) {
+    // force lowercase to make sure 2 users are not registered with the same wallet address, where
+    // one has uppercase letters (to be check summed), and the other does not
+    val address = walletAddress.toLowerCase(Locale.ROOT)
     val currentUser = supportRepository.getCurrentUser()
-    if (currentUser.userAddress != walletAddress || currentUser.gamificationLevel != level) {
-      if (currentUser.userAddress != walletAddress) {
+    if (currentUser.userAddress != address || currentUser.gamificationLevel != level) {
+      if (currentUser.userAddress != address) {
         Intercom.client()
             .logout()
       }
-      supportRepository.saveNewUser(walletAddress, level)
+      supportRepository.saveNewUser(address, level)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingInteractor.kt
@@ -7,6 +7,7 @@ import com.appcoins.wallet.gamification.Gamification
 import com.asfoundation.wallet.repository.PreferencesRepositoryType
 import com.asfoundation.wallet.support.SupportInteractor
 import io.reactivex.Single
+import java.util.*
 
 class OnboardingInteractor(private val walletService: WalletService,
                            private val preferencesRepositoryType: PreferencesRepositoryType,
@@ -15,9 +16,10 @@ class OnboardingInteractor(private val walletService: WalletService,
                            private val bdsRepository: BdsRepository) {
 
   fun getWalletAddress() = walletService.getWalletOrCreate()
-      .flatMap { address ->
+      .flatMap {
+        val address = it.toLowerCase(Locale.ROOT)
         gamificationRepository.getUserLevel(address)
-            .doOnSuccess { supportInteractor.registerUser(it, address) }
+            .doOnSuccess { level -> supportInteractor.registerUser(level, address) }
             .map { address }
       }
 

--- a/gamification/schemas/com.appcoins.wallet.gamification.repository.PromotionDatabase/4.json
+++ b/gamification/schemas/com.appcoins.wallet.gamification.repository.PromotionDatabase/4.json
@@ -1,0 +1,316 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "425a8c10cdd398272ee92ca54258912c",
+    "entities": [
+      {
+        "tableName": "PromotionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `priority` INTEGER NOT NULL, `bonus` REAL, `total_spend` TEXT, `total_earned` TEXT, `level` INTEGER, `next_level_amount` TEXT, `status` TEXT, `max_amount` TEXT, `available` INTEGER, `bundle` INTEGER, `completed` INTEGER, `currency` TEXT, `symbol` TEXT, `invited` INTEGER, `link` TEXT, `pending_amount` TEXT, `received_amount` TEXT, `user_status` TEXT, `min_amount` TEXT, `amount` TEXT, `current_progress` TEXT, `description` TEXT, `end_date` INTEGER, `icon` TEXT, `linked_promotion_id` TEXT, `objective_progress` TEXT, `start_date` INTEGER, `title` TEXT, `view_type` TEXT, `details_link` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bonus",
+            "columnName": "bonus",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalSpend",
+            "columnName": "total_spend",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalEarned",
+            "columnName": "total_earned",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextLevelAmount",
+            "columnName": "next_level_amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxAmount",
+            "columnName": "max_amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bundle",
+            "columnName": "bundle",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "invited",
+            "columnName": "invited",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pendingAmount",
+            "columnName": "pending_amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "receivedAmount",
+            "columnName": "received_amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userStatus",
+            "columnName": "user_status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minAmount",
+            "columnName": "min_amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currentProgress",
+            "columnName": "current_progress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "linkedPromotionId",
+            "columnName": "linked_promotion_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "objectiveProgress",
+            "columnName": "objective_progress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "viewType",
+            "columnName": "view_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "detailsLink",
+            "columnName": "details_link",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uid"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LevelsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `status` TEXT NOT NULL, `update_date` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateDate",
+            "columnName": "update_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LevelEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `amount` TEXT NOT NULL, `bonus` REAL NOT NULL, `level` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bonus",
+            "columnName": "bonus",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "WalletOriginEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_address` TEXT NOT NULL, `wallet_origin` TEXT NOT NULL, PRIMARY KEY(`wallet_address`))",
+        "fields": [
+          {
+            "fieldPath": "walletAddress",
+            "columnName": "wallet_address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletOrigin",
+            "columnName": "wallet_origin",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "wallet_address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '425a8c10cdd398272ee92ca54258912c')"
+    ]
+  }
+}

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionDao.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionDao.kt
@@ -1,9 +1,6 @@
 package com.appcoins.wallet.gamification.repository
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import com.appcoins.wallet.gamification.repository.entity.PromotionEntity
 import io.reactivex.Completable
 import io.reactivex.Single
@@ -14,10 +11,19 @@ interface PromotionDao {
   @Query("select * from PromotionEntity")
   fun getPromotions(): Single<List<PromotionEntity>>
 
-  @Query("DELETE FROM PromotionEntity")
-  fun deletePromotions(): Completable
+  @Transaction
+  fun deleteAndInsert(promotions: List<PromotionEntity>) {
+    // To ensure no concurrency issues occur (when trying to perform several deletions or
+    // insertions), the deletion+insertion needs to be a single transaction in DB
+    // This means that calling deletePromotions() or insertPromotions() separately should be avoided
+    deletePromotions()
+    insertPromotions(promotions)
+  }
 
-  @Insert(onConflict = OnConflictStrategy.REPLACE)
-  fun insertPromotions(promotions: List<PromotionEntity>): Completable
+  @Query("DELETE FROM PromotionEntity")
+  fun deletePromotions()
+
+  @Insert(onConflict = OnConflictStrategy.ABORT)
+  fun insertPromotions(promotions: List<PromotionEntity>)
 
 }

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionDatabase.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionDatabase.kt
@@ -12,7 +12,7 @@ import com.appcoins.wallet.gamification.repository.entity.WalletOriginEntity
 
 @Database(
     entities = [PromotionEntity::class, LevelsEntity::class, LevelEntity::class, WalletOriginEntity::class],
-    version = 3)
+    version = 4)
 @TypeConverters(PromotionConverter::class)
 abstract class PromotionDatabase : RoomDatabase() {
 
@@ -29,6 +29,23 @@ abstract class PromotionDatabase : RoomDatabase() {
       override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
             "CREATE TABLE IF NOT EXISTS WalletOriginEntity (wallet_address TEXT PRIMARY KEY NOT NULL, wallet_origin TEXT NOT NULL)")
+      }
+    }
+
+    //Changes the primary key of promotions table to one that can uniquely identify each promotion
+    //(since the 'id' field can be the same for several promotions)
+    val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+      override fun migrate(database: SupportSQLiteDatabase) {
+        //Since this involves changing the table structure (primary key), 4 steps need to be done:
+        // 1. Create a new table containing the new primary key, and all existing fields
+        database.execSQL(
+            "CREATE TABLE PromotionEntityNew (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `priority` INTEGER NOT NULL, `bonus` REAL, `total_spend` TEXT, `total_earned` TEXT, `level` INTEGER, `next_level_amount` TEXT, `status` TEXT, `max_amount` TEXT, `available` INTEGER, `bundle` INTEGER, `completed` INTEGER, `currency` TEXT, `symbol` TEXT, `invited` INTEGER, `link` TEXT, `pending_amount` TEXT, `received_amount` TEXT, `user_status` TEXT, `min_amount` TEXT, `amount` TEXT, `current_progress` TEXT, `description` TEXT, `end_date` INTEGER, `icon` TEXT, `linked_promotion_id` TEXT, `objective_progress` TEXT, `start_date` INTEGER, `title` TEXT, `view_type` TEXT, `details_link` TEXT)")
+        // 2. Copy the content from the old table to the new table
+        database.execSQL("INSERT INTO PromotionEntityNew(id, priority, bonus, total_spend, total_earned, level, next_level_amount, status, max_amount, available, bundle, completed, currency, symbol, invited, link, pending_amount, received_amount, user_status, min_amount, amount, current_progress, description, end_date, icon, linked_promotion_id, objective_progress, start_date, view_type, details_link) SELECT id, priority, bonus, total_spend, total_earned, level, next_level_amount, status, max_amount, available, bundle, completed, currency, symbol, invited, link, pending_amount, received_amount, user_status, min_amount, amount, current_progress, description, end_date, icon, linked_promotion_id, objective_progress, start_date, view_type, details_link FROM PromotionEntity")
+        // 3. Remove the old table
+        database.execSQL("DROP TABLE PromotionEntity")
+        // 4. Rename the new table to the old table's name
+        database.execSQL("ALTER TABLE PromotionEntityNew RENAME TO PromotionEntity")
       }
     }
   }

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/UserStatsLocalData.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/UserStatsLocalData.kt
@@ -25,9 +25,7 @@ interface UserStatsLocalData {
 
   fun getPromotions(): Single<List<PromotionsResponse>>
 
-  fun deletePromotions(): Completable
-
-  fun insertPromotions(promotions: List<PromotionsResponse>): Completable
+  fun deleteAndInsertPromotions(promotions: List<PromotionsResponse>): Completable
 
   fun deleteLevels(): Completable
 

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/WalletOriginDao.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/WalletOriginDao.kt
@@ -11,7 +11,7 @@ import io.reactivex.Single
 @Dao
 interface WalletOriginDao {
 
-  @Query("select * from WalletOriginEntity where wallet_address like :wallet")
+  @Query("select * from WalletOriginEntity where wallet_address = :wallet")
   fun getWalletOrigin(wallet: String): Single<WalletOriginEntity>
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/entity/PromotionEntity.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/entity/PromotionEntity.kt
@@ -5,9 +5,12 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.math.BigDecimal
 
+// a uid field needed to be created because the previous primary key ('id') was not necessarily
+// unique for all kinds of promotions.
 @Entity
 data class PromotionEntity(
-    @PrimaryKey val id: String,
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
+    val id: String,
     val priority: Int,
     val bonus: Double? = null,
     @ColumnInfo(name = "total_spend")

--- a/gamification/src/test/java/com/appcoins/wallet/gamification/UserStatsDataTest.kt
+++ b/gamification/src/test/java/com/appcoins/wallet/gamification/UserStatsDataTest.kt
@@ -53,7 +53,6 @@ class UserStatsDataTest : UserStatsLocalData {
 
   override fun getGamificationLevel(): Int = GamificationStats.INVALID_LEVEL
 
-  override fun deletePromotions(): Completable = Completable.complete()
 
   override fun getPromotions(): Single<List<PromotionsResponse>> {
     val aux = userStatusResponse!!
@@ -61,7 +60,7 @@ class UserStatsDataTest : UserStatsLocalData {
     return aux
   }
 
-  override fun insertPromotions(promotions: List<PromotionsResponse>): Completable {
+  override fun deleteAndInsertPromotions(promotions: List<PromotionsResponse>): Completable {
     return Completable.complete()
   }
 


### PR DESCRIPTION
**What does this PR do?**

   Fix issue related to only 1 perk being displayed with wifi off, even when there are multiple ones. The fix involved changing the primary key of the DB table to one that is 100% unique for each promotion. As such, it also involved a database migration.
   Furthermore, another bugfix was done in this PR: an issue where two wallet origins (type of user - APTOIDE, PARTNER, UNKNOWN) were being saved for the same wallet address. This only happened for the wallet created on the Onboarding Process (for wallets created on the balance screen or recovered wallets, this was not an issue). One of them (used just in Onboarding) had uppercase characters, but everywhere else it's the lowercase wallet address that is used. The fix was the following: when retrieving wallet origin, the comparison is now case sensitive (so that the outdated wallet origin is not retrieved); this means that old users will still have two wallet origins for the same wallet address, but the outdated one is never used; this avoids another migration of the PromotionDatabase . Furthermore, now onboarding process, as well as registers of users in intercom and zendesk, always use lowercase wallet address.

**Database changed?**

   Yes. The primary key of PromotionEntity table was changed, to one that autoincrements, to make sure all inserted promotions are different. This involved making a migration, and enforcing that each time one inserts the promotions, one must delete the DB content first.

**Where should the reviewer start?**

- [ ] PromotionDao.kt
- [ ] PromotionDatabase.kt

**How should this be manually tested?**

  QA Tickets related to testing 1 perk shown [APPC-2407](https://aptoide.atlassian.net/browse/APPC-2407)
  Regarding the other bug, take a non-UNKNOWN user, with wallet created on onboarding, and check if the content in promotions screen with WiFi off is that of an Aptoide user. Before, the wallet origin being sent from DB to the PromotionsInteractor was UNKNOWN. For a fresh install, confirm (e.g. with Database Inspector) that there is only one wallet origin per wallet address. You can also check if the wallet address being sent to intercom/zendesk is lowercase.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2407](https://aptoide.atlassian.net/browse/APPC-2407)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)
   Answer: No.



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass