### PR TITLE
Update debug apk file name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -262,12 +262,14 @@ dependencies {
 def renameArtifact(defaultConfig) {
   android.applicationVariants.all { variant ->
     variant.outputs.all {
-      def SEP = "_"
       def buildType = variant.buildType.name
       def versionName = variant.versionName
       def versionCode = defaultConfig.versionCode
-      def fileName =
-          "AppCoins_Wallet_v" + versionName + SEP + versionCode + SEP + buildType + ".apk"
+      def formattedDate = ""
+      if (buildType == "debug") {
+        formattedDate = "_" + new Date().format('yyMMdd-HHmm')
+      }
+      def fileName = "AppCoins_Wallet_v${versionName}_${versionCode}_${buildType}${formattedDate}.apk"
       outputFileName = new File("${fileName}")
     }
   }

--- a/app/staging/output-metadata.json
+++ b/app/staging/output-metadata.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "com.appcoins.wallet",
+  "variantName": "processStagingResources",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "versionCode": 193,
+      "versionName": "1.19.2.1.staging",
+      "outputFile": "AppCoins_Wallet_v1.19.2.1.staging_193_staging.apk"
+    }
+  ]
+}


### PR DESCRIPTION
Change apk file name when building debug so the file can be uploaded without a problem to pcloud since no version code nor version name are updated.
