### PR TITLE
hide withdraw screen while it's not production ready

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsFragment.kt
@@ -223,6 +223,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
   override fun setWithdrawPreference() {
     val bugReportPreference = findPreference<Preference>("pref_withdraw")
+    bugReportPreference?.isVisible = BuildConfig.DEBUG
     bugReportPreference?.setOnPreferenceClickListener {
       presenter.onWithdrawClicked()
       false

--- a/app/src/main/res/xml/fragment_settings.xml
+++ b/app/src/main/res/xml/fragment_settings.xml
@@ -14,7 +14,8 @@
       android:icon="@drawable/ic_withdraw"
       android:key="pref_withdraw"
       android:layout="@layout/preference_without_summary_layout"
-      android:title="@string/withdraw_funds" />
+      android:title="@string/withdraw_funds"
+      app:isPreferenceVisible="false" />
 
   <Preference
       android:icon="@drawable/ic_settings_redeem"


### PR DESCRIPTION
Signed-off-by: Trinkes <fabiojscosta1583@gmail.com>

**What does this PR do?**
   Hide withdraw screen while it's not production ready

**Database changed?**
   No

**Where should the reviewer start?**

- [ ] fragment_settings.xml

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass