### PR TITLE
[bugfix/APPC-2598] APPC-C IAP stuck even after completed

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
@@ -58,7 +58,7 @@ class AppcoinsRewardsBuyPresenter(private val view: AppcoinsRewardsBuyView,
     disposables.add(transferParser.parse(uri)
         .flatMapCompletable { transaction: TransactionBuilder ->
           rewardsManager.pay(
-              transaction.skuId, amount, transaction.toAddress(), packageName,
+              transaction.skuId, transaction.amount(), transaction.toAddress(), packageName,
               getOrigin(isBds, transaction), transaction.type, transaction.payload,
               transaction.callbackUrl, transaction.orderReference, transaction.referrerUrl,
               transaction.productToken


### PR DESCRIPTION
**What does this PR do?**

   There was a bug introduced with APPC-2525 that essentially APPC-C IAPs were getting stuck in loading even after they were completed. This PR addresses that.

**Database changed?**

   No

**How should this be manually tested?**

  Teste if APPC-C IAPs now work correctly.

**What are the relevant tickets?**

  [APPC-2598](https://aptoide.atlassian.net/browse/APPC-2598)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass