### PR TITLE
[bugfix/APPC-2588] Fixed issue with max level users seeing negative AppCoins

### DIFF
--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionConverter.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionConverter.kt
@@ -11,8 +11,8 @@ import java.util.*
 class PromotionConverter {
 
   @TypeConverter
-  fun fromString(value: String?): BigDecimal =
-      if (value == null || value.isBlank()) BigDecimal.ZERO else BigDecimal(value)
+  fun fromString(value: String?): BigDecimal? =
+      if (value == null || value.isBlank()) null else BigDecimal(value)
 
   @TypeConverter
   fun toString(bigDecimal: BigDecimal?): String? = bigDecimal?.toPlainString()


### PR DESCRIPTION
**What does this PR do?**

   Fixes an issue where users with max level was seeing negative AppCoins or 0 appcoins to reach next level (even though there's no next level).

**Database changed?**

   No

**How should this be manually tested?**

  Check with a wallet address with max level on promotions screen if it doesn't show the "0 AppCoins to reach next level" message.

**What are the relevant tickets?**

   [APPC-2588](https://aptoide.atlassian.net/browse/APPC-2588)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass