### PR TITLE
[task/APPC-2658] IAP Appc/Appc-c respect webservice order 

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -367,9 +367,11 @@ public class InAppPurchaseInteractor {
   private List<PaymentMethod> buildMergedList(List<PaymentMethod> paymentMethods,
       PaymentMethod appcMethod, PaymentMethod creditsMethod) {
     List<PaymentMethod> mergedList = new ArrayList<>();
+    boolean addedMergedAppc = false;
     for (PaymentMethod paymentMethod : paymentMethods) {
-      if (paymentMethod.getId()
-          .equals(APPC_ID)) {
+      if ((paymentMethod.getId()
+          .equals(APPC_ID) || paymentMethod.getId()
+          .equals(CREDITS_ID)) && !addedMergedAppc) {
         String mergedId = "merged_appcoins";
         String mergedLabel = appcMethod.getLabel() + " / " + creditsMethod.getLabel();
         boolean isMergedEnabled = appcMethod.isEnabled() || creditsMethod.isEnabled();
@@ -378,9 +380,10 @@ public class InAppPurchaseInteractor {
             isMergedEnabled, appcMethod.isEnabled(), creditsMethod.isEnabled(),
             appcMethod.getLabel(), creditsMethod.getLabel(), creditsMethod.getIconUrl(),
             disableReason, appcMethod.getDisabledReason(), creditsMethod.getDisabledReason()));
+        addedMergedAppc = true;
       } else if (!paymentMethod.getId()
-          .equals(CREDITS_ID)) {
-        //Don't add the credits method to this list
+          .equals(CREDITS_ID) && !paymentMethod.getId()
+          .equals(APPC_ID)) {
         mergedList.add(paymentMethod);
       }
     }

--- a/app/src/main/res/layout/merged_appcoins_layout.xml
+++ b/app/src/main/res/layout/merged_appcoins_layout.xml
@@ -65,9 +65,10 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/top_separator"
             >
+
           <include
-              android:id="@+id/appcoins_radio"
-              layout="@layout/appcoins_radio_button"
+              android:id="@+id/credits_radio"
+              layout="@layout/credits_radio_button"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginStart="24dp"
@@ -76,9 +77,11 @@
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toTopOf="parent"
+
               />
           <include
-              layout="@layout/skeleton_appcoins_layout"
+              android:id="@+id/skeleton_credits"
+              layout="@layout/skeleton_credits"
               android:layout_width="match_parent"
               android:layout_height="0dp"
               android:layout_marginStart="10dp"
@@ -95,14 +98,16 @@
               android:id="@+id/radio_middle_separator"
               android:layout_width="match_parent"
               android:layout_height="1dp"
+              android:layout_marginTop="24dp"
               android:background="@color/layout_separator_color"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toBottomOf="@id/appcoins_radio"
+              app:layout_constraintTop_toBottomOf="@id/credits_radio"
               />
+
           <include
-              android:id="@+id/credits_radio"
-              layout="@layout/credits_radio_button"
+              android:id="@+id/appcoins_radio"
+              layout="@layout/appcoins_radio_button"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginStart="24dp"
@@ -113,8 +118,7 @@
               app:layout_constraintTop_toBottomOf="@id/radio_middle_separator"
               />
           <include
-              android:id="@+id/skeleton_credits"
-              layout="@layout/skeleton_credits"
+              layout="@layout/skeleton_appcoins_layout"
               android:layout_width="match_parent"
               android:layout_height="0dp"
               android:layout_marginStart="10dp"
@@ -135,7 +139,7 @@
               android:background="@color/layout_separator_color"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toBottomOf="@id/credits_radio"
+              app:layout_constraintTop_toBottomOf="@id/appcoins_radio"
               />
           <androidx.constraintlayout.widget.Group
               android:id="@+id/payment_methods_group"


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes an issue where APPC/APPC-C options in IAP dialog was not respecting the order in webservice. It also changes the order from APPC -> APPC-C to APPC-C -> APPC in the MergedAppcoinsFragment screen.

**Database changed?**

   No

**How should this be manually tested?**

  Check that the payment methods order being shown in the IAP now respects the webservice. Also check that the order in MergedAppCoinsFragment screen is APPC-C then APPC.

**What are the relevant tickets?**

  [APPC-2658](https://aptoide.atlassian.net/browse/APPC-2658)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass