### PR TITLE
[bugfix/APPC-2690] Removes Payments Landscape Loading

### DIFF
--- a/app/src/main/res/layout-land/merged_appcoins_layout.xml
+++ b/app/src/main/res/layout-land/merged_appcoins_layout.xml
@@ -107,8 +107,8 @@
           app:layout_constraintTop_toTopOf="parent"
           >
         <include
-            android:id="@+id/appcoins_radio"
-            layout="@layout/appcoins_radio_button"
+            android:id="@+id/credits_radio"
+            layout="@layout/credits_radio_button"
             android:layout_width="match_parent"
             android:layout_height="102dp"
             android:layout_marginStart="10dp"
@@ -140,11 +140,11 @@
             android:background="@color/layout_separator_color"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appcoins_radio"
+            app:layout_constraintTop_toBottomOf="@id/credits_radio"
             />
         <include
-            android:id="@+id/credits_radio"
-            layout="@layout/credits_radio_button"
+            android:id="@+id/appcoins_radio"
+            layout="@layout/appcoins_radio_button"
             android:layout_width="match_parent"
             android:layout_height="108dp"
             android:layout_marginStart="10dp"

--- a/app/src/main/res/layout-land/payment_methods_layout.xml
+++ b/app/src/main/res/layout-land/payment_methods_layout.xml
@@ -21,7 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:indeterminateDrawable="@drawable/gradient_progress"
-        android:visibility="visible"
+        android:visibility="gone"
         />
 
     <LinearLayout


### PR DESCRIPTION

**What does this PR do?**

- removes visibility of loading from payments_methods land
- switches position of APPC with APPC-C in payment_methods land

**Database changed?**

No

**How should this be manually tested?**

- check if there is no loading animation behind the skeleton on the payments screen
- check if the payments order is APPC Credits first and then APPC in the  payments screen

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2690](https://aptoide.atlassian.net/browse/APPC-2690)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 
No.




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass