### PR TITLE
[ESKL-90/eskills] - pre select appcoins credits when the the payment method

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -525,6 +525,13 @@ class PaymentMethodsPresenter(
               isBonusActive, paymentMethodsData.frequency)
         }
       }
+    } else if (paymentMethods.size == 1
+        && paymentMethods[0].id == PaymentMethodId.APPC_CREDITS.id
+        && paymentMethods[0].isEnabled) {
+      showPaymentMethods(
+          fiatValue, paymentMethods, paymentMethods[0].id, fiatAmount, appcAmount,
+          paymentMethodsData.frequency
+      )
     } else {
       val paymentMethodId = getLastUsedPaymentMethod(paymentMethods)
       showPaymentMethods(fiatValue, paymentMethods, paymentMethodId, fiatAmount, appcAmount,


### PR DESCRIPTION
**What does this PR do?**

   Makes sure that when there is only one active payment method and it is APPC-C, it is pre selected on the payment methods list

**Database changed?**

    No

**How should this be manually tested?**

1. create a new clean wallet
2. open 2048 and enter in a live game(no sandbox)
3. make a top up
4. come back to payments list scree
5. check if appc-c payment method item is selected

**What are the relevant tickets?**

  Tickets related to this pull-request: [ESKL-90](https://aptoide.atlassian.net/browse/ESKL-90)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass