### PR TITLE
[APPC-2928] Make the project build and run on Apple M1 CPUs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 android {
-  buildToolsVersion '30.0.3'
-  compileSdkVersion 30
+  buildToolsVersion project.build_tools_version
+  compileSdkVersion project.compile_sdk_version
   ndkVersion "21.3.6528147"
   defaultConfig {
 
@@ -19,8 +19,8 @@ android {
     buildConfigField 'String', 'DEFAULT_STORE_ADDRESS', "\"" + json.stores.default_address + "\""
 
     applicationId "com.appcoins.wallet"
-    minSdkVersion 21
-    targetSdkVersion 30
+    minSdkVersion project.min_sdk_version
+    targetSdkVersion project.target_sdk_version
     versionCode 213
     versionName "2.3.2.1"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/billing/build.gradle
+++ b/billing/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion project.compile_sdk_version
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 28
+    minSdkVersion project.min_sdk_version
+    targetSdkVersion project.target_sdk_version
     versionCode 1
     versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ project.ext {
   rakam_version = '2.7.14'
   recyclerview_version = '1.1.0'
   retrofit_version = "2.8.1"
-  room_version = '2.2.5'
+  room_version = '2.2.4'
   rxandroid_version = '2.1.1'
   rxbinding_version = '2.1.1'
   rxjava_version = '2.2.19'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ allprojects {
   }
 }
 project.ext {
+  min_sdk_version = 21
+  compile_sdk_version = 30
+  target_sdk_version = 30
+  build_tools_version = '30.0.3'
   adyen_version = '3.6.6'
   androidx_browser_version = "1.3.0"
   appcompat_version = '1.2.0'

--- a/gamification/build.gradle
+++ b/gamification/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-  buildToolsVersion '29.0.3'
-  compileSdkVersion 29
+  buildToolsVersion project.build_tools_version
+  compileSdkVersion project.compile_sdk_version
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 29
+    minSdkVersion project.min_sdk_version
+    targetSdkVersion project.target_sdk_version
     versionCode 1
     versionName "1.0"
 

--- a/skills/build.gradle
+++ b/skills/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-  compileSdkVersion 29
-  buildToolsVersion '29.0.3'
+  compileSdkVersion project.compile_sdk_version
+  buildToolsVersion project.build_tools_version
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 29
+    minSdkVersion project.min_sdk_version
+    targetSdkVersion project.target_sdk_version
     versionCode 1
     versionName "1.0"
 


### PR DESCRIPTION
**What does this PR do?**

   This change make it possible to build and run project on the machines with Apple M1 CPU.

**Database changed?**

   No

**How should this be manually tested?**

  Check the main cases that involve working with DB and billing, gamification and skills modules.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2928](https://aptoide.atlassian.net/browse/APPC-2928)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
