### PR TITLE
[bugfix/APPC-2782] Backup triggers fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogFragment.kt
@@ -65,7 +65,8 @@ class BackupSaveOnDeviceDialogFragment : BottomSheetDialogFragment(),
 
   private fun createLaunchers() {
     openDocumentTreeResultLauncher = registerForActivityResult(
-      ActivityResultContracts.StartActivityForResult()) { activityResult ->
+      ActivityResultContracts.StartActivityForResult()
+    ) { activityResult ->
       val data = activityResult.data
       if (activityResult.resultCode == Activity.RESULT_OK && data != null) {
         data.data?.let {
@@ -75,15 +76,18 @@ class BackupSaveOnDeviceDialogFragment : BottomSheetDialogFragment(),
       }
     }
     requestPermissionsLauncher = registerForActivityResult(
-      ActivityResultContracts.RequestPermission()) { isGranted ->
+      ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
       if (isGranted) {
         viewModel.saveBackupFile(views.fileNameInput.getText())
       }
     }
   }
 
-  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                            savedInstanceState: Bundle?): View? {
+  override fun onCreateView(
+    inflater: LayoutInflater, container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
     return inflater.inflate(R.layout.backup_save_on_device_dialog_fragment, container, false)
   }
 
@@ -134,10 +138,13 @@ class BackupSaveOnDeviceDialogFragment : BottomSheetDialogFragment(),
     }
   }
 
-  override fun onSideEffect(sideEffect: BackupSaveOnDeviceDialogSideEffect) = when (sideEffect) {
-    BackupSaveOnDeviceDialogSideEffect.NavigateToSuccess -> navigator.navigateToSuccessScreen()
-    BackupSaveOnDeviceDialogSideEffect.ShowError -> showError()
-  }
+  override fun onSideEffect(sideEffect: BackupSaveOnDeviceDialogSideEffect) =
+    when (sideEffect) {
+      is BackupSaveOnDeviceDialogSideEffect.NavigateToSuccess -> navigator.navigateToSuccessScreen(
+        sideEffect.walletAddress
+      )
+      BackupSaveOnDeviceDialogSideEffect.ShowError -> showError()
+    }
 
   fun showError() {
     Toast.makeText(context, R.string.error_export, Toast.LENGTH_LONG)

--- a/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogNavigator.kt
@@ -1,12 +1,14 @@
 package com.asfoundation.wallet.backup.save_on_device
 
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
 import com.asf.wallet.R
 import com.asfoundation.wallet.backup.success.BackupSuccessFragment
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import javax.inject.Inject
 
-class BackupSaveOnDeviceDialogNavigator @Inject constructor(val fragment: Fragment) {
+class BackupSaveOnDeviceDialogNavigator @Inject constructor(val fragment: Fragment, val fragmentManager: FragmentManager) {
 
   fun dismiss() {
     (fragment as BottomSheetDialogFragment).dismiss()
@@ -16,11 +18,11 @@ class BackupSaveOnDeviceDialogNavigator @Inject constructor(val fragment: Fragme
     (fragment as BottomSheetDialogFragment).dismiss()
   }
 
-  fun navigateToSuccessScreen() {
-    fragment.requireFragmentManager().beginTransaction()
-        .replace(R.id.fragment_container, BackupSuccessFragment.newInstance(false))
-        .addToBackStack("SaveBackupDialogFragment")
-        .commit()
-    (fragment as BottomSheetDialogFragment).dismiss()
+  fun navigateToSuccessScreen(walletAddress: String) {
+    fragmentManager.commit {
+      replace(R.id.fragment_container, BackupSuccessFragment.newInstance(walletAddress, false))
+      addToBackStack("SaveBackupDialogFragment")
+    }
+    dismiss()
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_on_device/BackupSaveOnDeviceDialogViewModel.kt
@@ -9,7 +9,7 @@ import com.asfoundation.wallet.base.ViewState
 import java.io.File
 
 sealed class BackupSaveOnDeviceDialogSideEffect : SideEffect {
-  object NavigateToSuccess : BackupSaveOnDeviceDialogSideEffect()
+  data class NavigateToSuccess(val walletAddress: String) : BackupSaveOnDeviceDialogSideEffect()
   object ShowError : BackupSaveOnDeviceDialogSideEffect()
 }
 
@@ -38,13 +38,15 @@ class BackupSaveOnDeviceDialogViewModel(
     }
   }
 
-  fun saveBackupFile(fileName: String, filePath: DocumentFile? = downloadsPath?.let {
-    DocumentFile.fromFile(it)
-  }) {
+  fun saveBackupFile(
+    fileName: String, filePath: DocumentFile? = downloadsPath?.let {
+      DocumentFile.fromFile(it)
+    }
+  ) {
     saveBackupFileUseCase(data.walletAddress, data.password, fileName, filePath)
       .andThen(backupSuccessLogUseCase(data.walletAddress))
-      .doOnComplete { sendSideEffect { BackupSaveOnDeviceDialogSideEffect.NavigateToSuccess } }
-        .scopedSubscribe { showError(it) }
+      .doOnComplete { sendSideEffect { BackupSaveOnDeviceDialogSideEffect.NavigateToSuccess(data.walletAddress) } }
+      .scopedSubscribe { showError(it) }
   }
 
   private fun showError(throwable: Throwable) {

--- a/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsFragment.kt
@@ -48,8 +48,10 @@ class BackupSaveOptionsFragment : BasePageViewFragment(),
   }
 
 
-  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                            savedInstanceState: Bundle?): View? {
+  override fun onCreateView(
+    inflater: LayoutInflater, container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
     return inflater.inflate(R.layout.backup_save_options_fragment, container, false)
   }
 
@@ -59,8 +61,8 @@ class BackupSaveOptionsFragment : BasePageViewFragment(),
       override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
       override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
         views.emailButton.isEnabled =
-            s.isNotEmpty() && android.util.Patterns.EMAIL_ADDRESS.matcher(s)
-                .matches()
+          s.isNotEmpty() && android.util.Patterns.EMAIL_ADDRESS.matcher(s)
+            .matches()
       }
 
       override fun afterTextChanged(s: Editable) = Unit
@@ -69,7 +71,7 @@ class BackupSaveOptionsFragment : BasePageViewFragment(),
       viewModel.sendBackupToEmail(views.emailInput.getText())
     }
     views.emailButton.isEnabled =
-        false // this needs to be after setOnClickListener, otherwise button will be clickable
+      false // this needs to be after setOnClickListener, otherwise button will be clickable
     views.deviceButton.setOnClickListener {
       navigator.navigateToSaveOnDeviceScreen(
         requireArguments().getString(WALLET_ADDRESS_KEY)!!,
@@ -89,8 +91,11 @@ class BackupSaveOptionsFragment : BasePageViewFragment(),
 
   override fun onStateChanged(state: BackupSaveOptionsState) = Unit
 
-  override fun onSideEffect(sideEffect: BackupSaveOptionsSideEffect) = when (sideEffect) {
-    BackupSaveOptionsSideEffect.ShowError -> showError()
-    BackupSaveOptionsSideEffect.NavigateToSuccess -> navigator.navigateToSuccessScreen()
-  }
+  override fun onSideEffect(sideEffect: BackupSaveOptionsSideEffect) =
+    when (sideEffect) {
+      is BackupSaveOptionsSideEffect.NavigateToSuccess -> navigator.navigateToSuccessScreen(
+        sideEffect.walletAddress
+      )
+      BackupSaveOptionsSideEffect.ShowError -> showError()
+    }
 }

--- a/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsNavigator.kt
@@ -1,22 +1,23 @@
 package com.asfoundation.wallet.backup.save_options
 
-import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
 import com.asf.wallet.R
 import com.asfoundation.wallet.backup.save_on_device.BackupSaveOnDeviceDialogFragment
 import com.asfoundation.wallet.backup.success.BackupSuccessFragment
 import javax.inject.Inject
 
-class BackupSaveOptionsNavigator @Inject constructor(private val fragment: Fragment) {
+class BackupSaveOptionsNavigator @Inject constructor(private val fragmentManager: FragmentManager) {
 
   fun navigateToSaveOnDeviceScreen(walletAddress: String, password: String) {
     val bottomSheet = BackupSaveOnDeviceDialogFragment.newInstance(walletAddress, password)
-    bottomSheet.show(fragment.requireFragmentManager(), "SaveOnDeviceDialog")
+    bottomSheet.show(fragmentManager, "SaveOnDeviceDialog")
   }
 
-  fun navigateToSuccessScreen() {
-    fragment.requireFragmentManager().beginTransaction()
-      .replace(R.id.fragment_container, BackupSuccessFragment.newInstance(true))
-      .addToBackStack("BackupSaveOptionsFragment")
-        .commit()
+  fun navigateToSuccessScreen(walletAddress: String) {
+    fragmentManager.commit {
+      replace(R.id.fragment_container, BackupSuccessFragment.newInstance(walletAddress, false))
+      addToBackStack("BackupSaveOptionsFragment")
+    }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/save_options/BackupSaveOptionsViewModel.kt
@@ -8,7 +8,7 @@ import com.asfoundation.wallet.base.SideEffect
 import com.asfoundation.wallet.base.ViewState
 
 sealed class BackupSaveOptionsSideEffect : SideEffect {
-  object NavigateToSuccess : BackupSaveOptionsSideEffect()
+  data class NavigateToSuccess(val walletAddress: String) : BackupSaveOptionsSideEffect()
   object ShowError : BackupSaveOptionsSideEffect()
 }
 
@@ -35,8 +35,8 @@ class BackupSaveOptionsViewModel(
   fun sendBackupToEmail(text: String) {
     sendBackupToEmailUseCase(data.walletAddress, data.password, text)
       .andThen(backupSuccessLogUseCase(data.walletAddress))
-      .doOnComplete { sendSideEffect { BackupSaveOptionsSideEffect.NavigateToSuccess } }
-        .scopedSubscribe { showError(it) }
+      .doOnComplete { sendSideEffect { BackupSaveOptionsSideEffect.NavigateToSuccess(data.walletAddress) } }
+      .scopedSubscribe { showError(it) }
   }
 
   private fun showError(throwable: Throwable) {

--- a/app/src/main/java/com/asfoundation/wallet/backup/skip/BackupSkipDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/skip/BackupSkipDialogFragment.kt
@@ -53,7 +53,9 @@ class BackupSkipDialogFragment : BottomSheetDialogFragment(),
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     views.confirm.setOnClickListener {
-      navigator.finishBackup()
+      navigator.finishBackup(
+        requireArguments().getString(BackupTriggerDialogFragment.WALLET_ADDRESS_KEY)!!
+      )
     }
     views.cancel.setOnClickListener {
       navigator.navigateBack(

--- a/app/src/main/java/com/asfoundation/wallet/backup/skip/BackupSkipDialogNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/skip/BackupSkipDialogNavigator.kt
@@ -18,8 +18,9 @@ class BackupSkipDialogNavigator @Inject constructor(
     bottomSheet.show(fragment.parentFragmentManager, "BackupTriggerFromSkip")
   }
 
-  fun finishBackup() {
+  fun finishBackup(walletAddress: String) {
     backupTriggerPreferences.setTriggerState(
+      walletAddress = walletAddress,
       active = false,
       triggerSource = BackupTriggerPreferences.TriggerSource.DISABLED
     )

--- a/app/src/main/java/com/asfoundation/wallet/backup/success/BackupSuccessFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/success/BackupSuccessFragment.kt
@@ -26,12 +26,14 @@ class BackupSuccessFragment : BasePageViewFragment(),
 
   companion object {
     const val EMAIL_KEY = "email"
+    const val WALLET_ADDRESS_KEY = "wallet_address_key"
 
     @JvmStatic
-    fun newInstance(email: Boolean): BackupSuccessFragment {
+    fun newInstance(walletAddress: String, email: Boolean): BackupSuccessFragment {
       return BackupSuccessFragment()
         .apply {
           arguments = Bundle().apply {
+            putString(WALLET_ADDRESS_KEY, walletAddress)
             putBoolean(EMAIL_KEY, email)
           }
         }
@@ -51,6 +53,7 @@ class BackupSuccessFragment : BasePageViewFragment(),
     views.closeButton.setOnClickListener {
       this.activity?.finish()
       backupTriggerPreferences.setTriggerState(
+        walletAddress = requireArguments().getString(WALLET_ADDRESS_KEY, ""),
         active = false,
         triggerSource = BackupTriggerPreferences.TriggerSource.DISABLED
       )

--- a/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogFragment.kt
@@ -1,7 +1,6 @@
 package com.asfoundation.wallet.backup.triggers
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -58,13 +57,12 @@ class BackupTriggerDialogFragment : BottomSheetDialogFragment(),
     setListeners()
   }
 
-  //TODO design doesn't include string context for each trigger source, so its commented for now
   private fun setUIContext() {
     when (requireArguments().getSerializable(TRIGGER_SOURCE)!!) {
-//      BackupTriggerPreferences.TriggerSource.NEW_LEVEL -> views.triggerDialogMessage.text =
-//        getString(R.string.backup_skip_title)
-//      BackupTriggerPreferences.TriggerSource.FIRST_PURCHASE -> views.triggerDialogMessage.text =
-//        getString(R.string.backup_skip_title)
+      BackupTriggerPreferences.TriggerSource.NEW_LEVEL -> views.triggerDialogMessage.text =
+        getString(R.string.backup_popup_gamification_body)
+      BackupTriggerPreferences.TriggerSource.FIRST_PURCHASE -> views.triggerDialogMessage.text =
+        getString(R.string.backup_popup_purchase_body)
       else -> {}
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerPreferences.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerPreferences.kt
@@ -7,25 +7,20 @@ import javax.inject.Inject
 
 class BackupTriggerPreferences @Inject constructor(private val pref: SharedPreferences) {
 
-  companion object {
-    private const val BACKUP_TRIGGER_STATE = "backup_trigger_state"
-    private const val BACKUP_TRIGGER_SOURCE = "backup_trigger_source"
-  }
-
-  fun setTriggerState(active: Boolean, triggerSource: TriggerSource) {
+  fun setTriggerState(walletAddress: String, active: Boolean, triggerSource: TriggerSource) {
     pref.edit()
-      .putBoolean(BACKUP_TRIGGER_STATE, active)
-      .putString(BACKUP_TRIGGER_SOURCE, Gson().toJson(triggerSource))
+      .putBoolean("backup_trigger_state$walletAddress", active)
+      .putString("backup_trigger_source$walletAddress", Gson().toJson(triggerSource))
       .apply()
   }
 
-  fun getTriggerState(): Boolean {
-    return pref.getBoolean(BACKUP_TRIGGER_STATE, false)
+  fun getTriggerState(walletAddress: String): Boolean {
+    return pref.getBoolean("backup_trigger_state$walletAddress", false)
   }
 
-  fun getTriggerSource(): TriggerSource {
+  fun getTriggerSource(walletAddress: String): TriggerSource {
     return Gson().fromJson(
-      pref.getString(BACKUP_TRIGGER_SOURCE, TriggerSource.NOT_SEEN.toString()),
+      pref.getString("backup_trigger_source$walletAddress", TriggerSource.NOT_SEEN.toString()),
       TriggerSource::class.java
     )
   }

--- a/app/src/main/java/com/asfoundation/wallet/transactions/PerkBonusAndGamificationService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/transactions/PerkBonusAndGamificationService.kt
@@ -125,6 +125,7 @@ class PerkBonusAndGamificationService :
       )
     ) {
       backupTriggerPreferences.setTriggerState(
+        walletAddress = address,
         active = true,
         triggerSource = BackupTriggerPreferences.TriggerSource.NEW_LEVEL
       )

--- a/app/src/main/res/layout/backup_trigger_dialog_fragment.xml
+++ b/app/src/main/res/layout/backup_trigger_dialog_fragment.xml
@@ -43,7 +43,7 @@
       android:gravity="center"
       android:fontFamily="@font/roboto_medium"
       android:textSize="@dimen/backup_m_text_size"
-      android:text="@string/backup_popup_body"
+      android:text="@string/backup_popup_purchase_body"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/trigger_dialog_title"


### PR DESCRIPTION
**What does this PR do?**

   After changing wallets, the backup bottomsheet would work according to what happened to the previous wallet.
   Added context when saving in the shared prefs with the wallet key, but in the future this might make more sense to simply change to a db.
   Now the user can change wallets and the bottomsheet will appear when it should

**Database changed?**

   No

**Where should the reviewer start?**

- BackupTriggersPreferences.kt
- HomeViewModel.kt

**How should this be manually tested?**

- Recover a wallet that has a least one transaction
- Close the app and open to show the trigger
- dismiss the bottom sheet
- Change wallet to a new one (the trigger show not appear in all cases but another test is to see if it opens when the dismiss of the previous wallet was not done, it should appear anyway)
- top up the new wallet and check if it will show the tigger

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-2782

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
