### PR TITLE
[bugfix/APPC-2782] [bugfix/APPC-3045] Backup triggers and promo code bonus fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/backup/success/BackupSuccessFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/success/BackupSuccessFragment.kt
@@ -49,14 +49,14 @@ class BackupSuccessFragment : BasePageViewFragment(),
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    backupTriggerPreferences.setTriggerState(
+      walletAddress = requireArguments().getString(WALLET_ADDRESS_KEY, ""),
+      active = false,
+      triggerSource = BackupTriggerPreferences.TriggerSource.DISABLED
+    )
 
     views.closeButton.setOnClickListener {
       this.activity?.finish()
-      backupTriggerPreferences.setTriggerState(
-        walletAddress = requireArguments().getString(WALLET_ADDRESS_KEY, ""),
-        active = false,
-        triggerSource = BackupTriggerPreferences.TriggerSource.DISABLED
-      )
     }
 
     setSuccessInfo()

--- a/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogNavigator.kt
@@ -10,6 +10,7 @@ import javax.inject.Inject
 class BackupTriggerDialogNavigator @Inject constructor(val fragment: Fragment) {
 
   fun navigateToBackupActivity(walletAddress: String) {
+    (fragment as BottomSheetDialogFragment).dismiss()
     val intent =
       BackupActivity.newIntent(fragment.requireContext(), walletAddress, isBackupTrigger = true)
         .apply {

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/PromoCodeBottomSheetViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/PromoCodeBottomSheetViewModel.kt
@@ -5,10 +5,7 @@ import com.asfoundation.wallet.base.BaseViewModel
 import com.asfoundation.wallet.base.SideEffect
 import com.asfoundation.wallet.base.ViewState
 import com.asfoundation.wallet.promo_code.repository.PromoCode
-import com.asfoundation.wallet.promo_code.use_cases.DeletePromoCodeUseCase
-import com.asfoundation.wallet.promo_code.use_cases.GetCurrentPromoCodeUseCase
-import com.asfoundation.wallet.promo_code.use_cases.GetUpdatedPromoCodeUseCase
-import com.asfoundation.wallet.promo_code.use_cases.SetPromoCodeUseCase
+import com.asfoundation.wallet.promo_code.use_cases.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -22,7 +19,7 @@ data class PromoCodeBottomSheetState(val promoCodeAsync: Async<PromoCode> = Asyn
 
 @HiltViewModel
 class PromoCodeBottomSheetViewModel @Inject constructor(
-  private val getCurrentPromoCodeUseCase: GetCurrentPromoCodeUseCase,
+  private val observePromoCodeUseCase: ObservePromoCodeUseCase,
   private val setPromoCodeUseCase: SetPromoCodeUseCase,
   private val deletePromoCodeUseCase: DeletePromoCodeUseCase) :
     BaseViewModel<PromoCodeBottomSheetState, PromoCodeBottomSheetSideEffect>(initialState()) {
@@ -38,7 +35,7 @@ class PromoCodeBottomSheetViewModel @Inject constructor(
   }
 
   private fun getCurrentPromoCode() {
-    getCurrentPromoCodeUseCase()
+    observePromoCodeUseCase()
         .asAsyncToState { copy(promoCodeAsync = it) }
         .repeatableScopedSubscribe(PromoCodeBottomSheetState::promoCodeAsync.name) { e ->
           e.printStackTrace()


### PR DESCRIPTION
**What does this PR do?**

   Fixes the navigation from the backup triggers bottom sheet to the backup activity, since when a user completed a backup, returning to home would still have the bottom sheet because it wasn't dismissed.
  Also fixes the bonus of the promocode not showing correctly when adding a promo code

**How should this be manually tested?**

  - navigate to backup from the triggers (when returning, the bottom sheet wont be there, it will only be when the user opens the app again)
  - complete the backup and check that even after closing, the bottom sheet wont appear anymore
  
**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-2782
  https://aptoide.atlassian.net/browse/APPC-3045

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
