### PR TITLE
[bugfix/appc 2782] Backup new level triggers fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/home/usecases/GetLastShownUserLevelUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/usecases/GetLastShownUserLevelUseCase.kt
@@ -1,0 +1,20 @@
+package com.asfoundation.wallet.home.usecases
+
+import com.appcoins.wallet.gamification.Gamification
+import com.appcoins.wallet.gamification.GamificationContext
+import com.appcoins.wallet.gamification.repository.GamificationStats
+import com.appcoins.wallet.gamification.repository.Levels
+import com.appcoins.wallet.gamification.repository.PromotionsRepository
+import io.reactivex.Single
+import javax.inject.Inject
+
+class GetLastShownUserLevelUseCase @Inject constructor(private val promotionsRepository: PromotionsRepository) {
+
+  operator fun invoke(address: String): Single<Int> {
+    return promotionsRepository.getLastShownLevel(
+      address,
+      GamificationContext.NOTIFICATIONS_LEVEL_UP
+    )
+      .map { if (it == GamificationStats.INVALID_LEVEL) 0 else it }
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/home/usecases/UpdateLastShownUserLevelUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/usecases/UpdateLastShownUserLevelUseCase.kt
@@ -1,0 +1,19 @@
+package com.asfoundation.wallet.home.usecases
+
+import com.appcoins.wallet.gamification.Gamification
+import com.appcoins.wallet.gamification.GamificationContext
+import com.appcoins.wallet.gamification.repository.GamificationStats
+import com.appcoins.wallet.gamification.repository.Levels
+import com.appcoins.wallet.gamification.repository.PromotionsRepository
+import io.reactivex.Single
+import javax.inject.Inject
+
+class UpdateLastShownUserLevelUseCase @Inject constructor(private val promotionsRepository: PromotionsRepository) {
+
+  operator fun invoke(address: String, currentLevel: Int) {
+    return promotionsRepository.shownLevel(
+      address, currentLevel,
+      GamificationContext.NOTIFICATIONS_LEVEL_UP
+    )
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   fixed trigger when leveling up, now should trigger both from the notification but also from home

**Database changed?**

   No

**How should this be manually tested?**

  - make a payment in trivial drive to turn on promotions
  - top up 20eur to level up
  - restart the app and check the trigger
  - top up 30eur and check the next level as well

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-2782

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
