### PR TITLE
Error web calls to Sentry

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
@@ -72,12 +72,11 @@ internal class AppModule {
 
   @Singleton
   @Provides
-  fun provideLogger(sendLogsRepository: SendLogsRepository): Logger {
+  fun provideLogger(): Logger {
     val receivers = ArrayList<LogReceiver>()
     if (BuildConfig.DEBUG) {
       receivers.add(DebugReceiver())
     }
-    receivers.add(SendLogsReceiver(sendLogsRepository))
     return WalletLogger(receivers)
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/logging/DebugReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/DebugReceiver.kt
@@ -13,7 +13,7 @@ class DebugReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?, asError: Boolean) {
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) {
     if (BuildConfig.DEBUG && message != null) {
       Log.e(tag ?: "Logger", message)
     }

--- a/app/src/main/java/com/asfoundation/wallet/logging/DebugReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/DebugReceiver.kt
@@ -13,7 +13,7 @@ class DebugReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?) {
+  override fun log(tag: String?, message: String?, asError: Boolean) {
     if (BuildConfig.DEBUG && message != null) {
       Log.e(tag ?: "Logger", message)
     }

--- a/app/src/main/java/com/asfoundation/wallet/logging/FlurryReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/FlurryReceiver.kt
@@ -19,7 +19,7 @@ class FlurryReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?, asError: Boolean) {
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) {
     message?.let {
       if (!BuildConfig.DEBUG) {
         FlurryAgent.onError(tag ?: DEFAULT_ERROR_ID, message, Throwable())

--- a/app/src/main/java/com/asfoundation/wallet/logging/FlurryReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/FlurryReceiver.kt
@@ -19,7 +19,7 @@ class FlurryReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?) {
+  override fun log(tag: String?, message: String?, asError: Boolean) {
     message?.let {
       if (!BuildConfig.DEBUG) {
         FlurryAgent.onError(tag ?: DEFAULT_ERROR_ID, message, Throwable())

--- a/app/src/main/java/com/asfoundation/wallet/logging/RakamReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/RakamReceiver.kt
@@ -18,7 +18,7 @@ class RakamReceiver : LogReceiver {
         .logEvent(LOG_EVENT_TYPE, map(tag, null, throwable))
   }
 
-  override fun log(tag: String?, message: String?) {
+  override fun log(tag: String?, message: String?, asError: Boolean) {
     Rakam.getInstance()
         .logEvent(LOG_EVENT_TYPE, map(tag, message, null))
   }

--- a/app/src/main/java/com/asfoundation/wallet/logging/RakamReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/RakamReceiver.kt
@@ -18,7 +18,7 @@ class RakamReceiver : LogReceiver {
         .logEvent(LOG_EVENT_TYPE, map(tag, null, throwable))
   }
 
-  override fun log(tag: String?, message: String?, asError: Boolean) {
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) {
     Rakam.getInstance()
         .logEvent(LOG_EVENT_TYPE, map(tag, message, null))
   }

--- a/app/src/main/java/com/asfoundation/wallet/logging/SentryReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/SentryReceiver.kt
@@ -2,6 +2,8 @@ package com.asfoundation.wallet.logging
 
 import com.appcoins.wallet.commons.LogReceiver
 import io.sentry.Sentry
+import io.sentry.event.Breadcrumb
+import io.sentry.event.BreadcrumbBuilder
 import io.sentry.event.Event
 import io.sentry.event.EventBuilder
 
@@ -13,7 +15,7 @@ class SentryReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?, asError: Boolean) {
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) {
     message?.let {
       if (asError) {
         val errorEvent = EventBuilder()
@@ -22,6 +24,17 @@ class SentryReceiver : LogReceiver {
         Sentry.capture(errorEvent)
       } else {
         Sentry.capture("$tag: $message")
+      }
+      if (addToBreadcrumbs) {
+        Sentry.getContext().recordBreadcrumb(
+          BreadcrumbBuilder()
+            .setType(Breadcrumb.Type.DEFAULT)
+            .setLevel(Breadcrumb.Level.ERROR)
+            .setMessage(tag)
+            .setCategory(tag)
+            .setData(mapOf(Pair("error", message)))
+            .build()
+        )
       }
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/logging/SentryReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/SentryReceiver.kt
@@ -2,6 +2,8 @@ package com.asfoundation.wallet.logging
 
 import com.appcoins.wallet.commons.LogReceiver
 import io.sentry.Sentry
+import io.sentry.event.Event
+import io.sentry.event.EventBuilder
 
 class SentryReceiver : LogReceiver {
 
@@ -11,9 +13,16 @@ class SentryReceiver : LogReceiver {
     }
   }
 
-  override fun log(tag: String?, message: String?) {
+  override fun log(tag: String?, message: String?, asError: Boolean) {
     message?.let {
-      Sentry.capture("$tag: $message")
+      if (asError) {
+        val errorEvent = EventBuilder()
+        errorEvent.withLevel(Event.Level.ERROR)
+        errorEvent.withMessage(it)
+        Sentry.capture(errorEvent)
+      } else {
+        Sentry.capture("$tag: $message")
+      }
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/logging/WalletLogger.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/WalletLogger.kt
@@ -6,8 +6,8 @@ import javax.inject.Inject
 
 class WalletLogger @Inject constructor(private var logReceivers: ArrayList<LogReceiver>): Logger {
 
-  override fun log(tag: String?, message: String?) {
-    logReceivers.forEach { receiver -> message?.let { message -> receiver.log(tag, message) } }
+  override fun log(tag: String?, message: String?, asError: Boolean) {
+    logReceivers.forEach { receiver -> message?.let { message -> receiver.log(tag, message, asError) } }
   }
 
   override fun log(tag: String?, throwable: Throwable?) {

--- a/app/src/main/java/com/asfoundation/wallet/logging/WalletLogger.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/WalletLogger.kt
@@ -6,8 +6,8 @@ import javax.inject.Inject
 
 class WalletLogger @Inject constructor(private var logReceivers: ArrayList<LogReceiver>): Logger {
 
-  override fun log(tag: String?, message: String?, asError: Boolean) {
-    logReceivers.forEach { receiver -> message?.let { message -> receiver.log(tag, message, asError) } }
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) {
+    logReceivers.forEach { receiver -> message?.let { message -> receiver.log(tag, message, asError, addToBreadcrumbs) } }
   }
 
   override fun log(tag: String?, throwable: Throwable?) {

--- a/app/src/main/java/com/asfoundation/wallet/logging/send_logs/SendLogsReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/send_logs/SendLogsReceiver.kt
@@ -9,7 +9,7 @@ class SendLogsReceiver(private var sendLogsRepository: SendLogsRepository) : Log
         .subscribe()
   }
 
-  override fun log(tag: String?, message: String?) = Unit
+  override fun log(tag: String?, message: String?, asError: Boolean) = Unit
 
   override fun log(tag: String?, message: String?, throwable: Throwable?) {
     sendLogsRepository.saveLog(tag, map(message = message, throwable = throwable))

--- a/app/src/main/java/com/asfoundation/wallet/logging/send_logs/SendLogsReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/logging/send_logs/SendLogsReceiver.kt
@@ -9,7 +9,7 @@ class SendLogsReceiver(private var sendLogsRepository: SendLogsRepository) : Log
         .subscribe()
   }
 
-  override fun log(tag: String?, message: String?, asError: Boolean) = Unit
+  override fun log(tag: String?, message: String?, asError: Boolean, addToBreadcrumbs: Boolean) = Unit
 
   override fun log(tag: String?, message: String?, throwable: Throwable?) {
     sendLogsRepository.saveLog(tag, map(message = message, throwable = throwable))

--- a/app/src/main/java/com/asfoundation/wallet/util/LogInterceptor.java
+++ b/app/src/main/java/com/asfoundation/wallet/util/LogInterceptor.java
@@ -2,13 +2,11 @@ package com.asfoundation.wallet.util;
 
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
-import com.asfoundation.wallet.logging.send_logs.db.LogEntity;
-import com.asfoundation.wallet.logging.send_logs.db.LogsDao;
+import com.appcoins.wallet.commons.Logger;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import okhttp3.Headers;
@@ -28,10 +26,11 @@ public class LogInterceptor implements Interceptor {
   private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   // Dao is being used directly because otherwise we'll have a cyclic dependency with Repository
-  private LogsDao logsDao;
+  //private LogsDao logsDao;
+  @Inject Logger logger;
 
-  public @Inject LogInterceptor(LogsDao logsDao) {
-    this.logsDao = logsDao;
+  public @Inject LogInterceptor() {
+    //this.logger = logger;
   }
 
   private static String requestPath(HttpUrl url) {
@@ -72,15 +71,8 @@ public class LogInterceptor implements Interceptor {
       logBuilder.append("\n=============== END Headers ===============\n");
 
       if (requestBody != null) {
-        Buffer buffer = new Buffer();
-        requestBody.writeTo(buffer);
-
-        MediaType contentType = requestBody.contentType();
-        if (contentType != null) {
-          contentType.charset(UTF8);
-        }
-
-        logBuilder.append(buffer.readString(UTF8));
+        String requestSting = formatRequestBody(requestBody);
+        logBuilder.append(requestSting);
       }
       long startNs = System.nanoTime();
       Response response = chain.proceed(request);
@@ -99,27 +91,14 @@ public class LogInterceptor implements Interceptor {
           .append(response.code());
 
       if (responseBody != null) {
-        BufferedSource source = responseBody.source();
-        source.request(Long.MAX_VALUE); // Buffer the entire body.
-        Buffer buffer = source.getBuffer();
-
-        Charset charset = null;
-        MediaType contentType = responseBody.contentType();
-        if (contentType != null) {
-          charset = contentType.charset(UTF8);
-        }
-
-        if (charset == null) {
-          charset = UTF8;
-        }
-
+        String responseString = formatResponseBody(responseBody);
         if (responseBody.contentLength() != 0) {
           logBuilder.append("\n");
           logBuilder.append("Response body: \n")
-              .append(buffer.clone()
-                  .readString(charset));
+              .append(responseString);
         }
       }
+
       headers = response.headers();
       logBuilder.append("\n=============== Headers ===============\n");
       for (int i = headers.size() - 1; i > -1; i--) {
@@ -138,6 +117,7 @@ public class LogInterceptor implements Interceptor {
 
       if (response.code() >= 400) {
         saveLog(logBuilder.toString());
+        sendErrorLogString(response, request);
       }
       return response;
     } catch (Exception exception) {
@@ -151,8 +131,54 @@ public class LogInterceptor implements Interceptor {
     }
   }
 
+  private void sendErrorLogString(Response response, Request request) throws IOException {
+    StringBuilder logBuilder = new StringBuilder();
+
+    logBuilder.append("HTTP " + response.code() + "\n");
+    logBuilder.append("" + request.method() + " " + request.url() + "\n");
+    logBuilder.append("Request: " + formatRequestBody(response.request().body()) + "\n");
+    logBuilder.append("Response: " + formatResponseBody(response.body()) + "\n");
+    logBuilder.append("Message: " + response.message() + "\n");
+
+    logger.log("HTTP " + response.code(), logBuilder.toString(), true);
+  }
+
+  private String formatResponseBody(ResponseBody responseBody) throws IOException {
+    if (responseBody != null) {
+      BufferedSource source = responseBody.source();
+      source.request(Long.MAX_VALUE);
+      Buffer buffer = source.getBuffer();
+      Charset charset = null;
+      MediaType contentType = responseBody.contentType();
+      if (contentType != null) {
+        charset = contentType.charset(UTF8);
+      }
+      if (charset == null) {
+        charset = UTF8;
+      }
+      return buffer.clone().readString(charset);
+    } else {
+      return "";
+    }
+  }
+
+  private String formatRequestBody(RequestBody requestBody) throws IOException {
+    if (requestBody != null) {
+      Buffer buffer = new Buffer();
+      requestBody.writeTo(buffer);
+
+      MediaType contentType = requestBody.contentType();
+      if (contentType != null) {
+        contentType.charset(UTF8);
+      }
+
+      return buffer.readString(UTF8);
+    }
+    return "";
+  }
+
   private void saveLog(String log) {
-    logsDao.saveLog(new LogEntity(null, Instant.now(), TAG, log, false), 15);
+    //logsDao.saveLog(new LogEntity(null, Instant.now(), TAG, log, false), 15);
   }
 
   private String requestDecodedPath(HttpUrl url) {

--- a/app/src/main/java/com/asfoundation/wallet/util/LogInterceptor.java
+++ b/app/src/main/java/com/asfoundation/wallet/util/LogInterceptor.java
@@ -133,14 +133,27 @@ public class LogInterceptor implements Interceptor {
 
   private void sendErrorLogString(Response response, Request request) throws IOException {
     StringBuilder logBuilder = new StringBuilder();
+    logBuilder.append("HTTP ")
+        .append(response.code())
+        .append(" ")
+        .append(request.method())
+        .append(" ")
+        .append(request.url())
+        .append("\n")
 
-    logBuilder.append("HTTP " + response.code() + "\n");
-    logBuilder.append("" + request.method() + " " + request.url() + "\n");
-    logBuilder.append("Request: " + formatRequestBody(response.request().body()) + "\n");
-    logBuilder.append("Response: " + formatResponseBody(response.body()) + "\n");
-    logBuilder.append("Message: " + response.message() + "\n");
+        .append("Request: ")
+        .append(formatRequestBody(response.request().body()))
+        .append("\n")
 
-    logger.log("HTTP " + response.code(), logBuilder.toString(), true);
+        .append("Response: ")
+        .append(formatResponseBody(response.body()))
+        .append("\n")
+
+        .append("Message: ")
+        .append(response.message())
+        .append("\n");
+
+    logger.log("HTTP " + response.code(), logBuilder.toString(), true, true);
   }
 
   private String formatResponseBody(ResponseBody responseBody) throws IOException {

--- a/commons/src/main/java/com/appcoins/wallet/commons/LogReceiver.kt
+++ b/commons/src/main/java/com/appcoins/wallet/commons/LogReceiver.kt
@@ -8,6 +8,6 @@ interface LogReceiver {
     const val DEFAULT_THROWABLE_STATCKTRACE = "default_throwable_stacktrace"
   }
   fun log(tag: String?, throwable: Throwable?)
-  fun log(tag: String?, message: String?)
+  fun log(tag: String?, message: String?, asError: Boolean = false)
   fun log(tag: String?, message: String?, throwable: Throwable?)
 }

--- a/commons/src/main/java/com/appcoins/wallet/commons/LogReceiver.kt
+++ b/commons/src/main/java/com/appcoins/wallet/commons/LogReceiver.kt
@@ -8,6 +8,6 @@ interface LogReceiver {
     const val DEFAULT_THROWABLE_STATCKTRACE = "default_throwable_stacktrace"
   }
   fun log(tag: String?, throwable: Throwable?)
-  fun log(tag: String?, message: String?, asError: Boolean = false)
+  fun log(tag: String?, message: String?, asError: Boolean = false, addToBreadcrumbs: Boolean = false)
   fun log(tag: String?, message: String?, throwable: Throwable?)
 }

--- a/commons/src/main/java/com/appcoins/wallet/commons/Logger.kt
+++ b/commons/src/main/java/com/appcoins/wallet/commons/Logger.kt
@@ -1,7 +1,7 @@
 package com.appcoins.wallet.commons
 
 interface Logger {
-  fun log(tag: String?, message: String?)
+  fun log(tag: String?, message: String?, asError: Boolean = false)
   fun log(tag: String?, throwable: Throwable?)
   fun log(tag: String?, message: String?, throwable: Throwable?)
   fun addReceiver(receiver: LogReceiver)

--- a/commons/src/main/java/com/appcoins/wallet/commons/Logger.kt
+++ b/commons/src/main/java/com/appcoins/wallet/commons/Logger.kt
@@ -1,7 +1,7 @@
 package com.appcoins.wallet.commons
 
 interface Logger {
-  fun log(tag: String?, message: String?, asError: Boolean = false)
+  fun log(tag: String?, message: String?, asError: Boolean = false, addToBreadcrumbs: Boolean = false)
   fun log(tag: String?, throwable: Throwable?)
   fun log(tag: String?, message: String?, throwable: Throwable?)
   fun addReceiver(receiver: LogReceiver)


### PR DESCRIPTION
**What does this PR do?**
If a web call has an error response code then registers the error to Sentry as an event. 
The error is also added to the breadcrumbs list, so any following error will show it.
This PR should go together with the removal of the log file.

**How should this be manually tested?**
 - In the app's settings, introduce an invalid promo code. This will return a 404.
 - On Sentry, filter by wallet and check the error.

To test the breadcrumbs:
 - Introduce two invalid promo codes, this should log multiple error events.
 - On Sentry, check the second error and see the breadcrumbs from the first event.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3086

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
