### PR TITLE
[task/APPC-3122] Clear Onboarding backstack

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/base/Navigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/base/Navigator.kt
@@ -2,7 +2,6 @@ package com.asfoundation.wallet.base
 
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
-import androidx.navigation.fragment.FragmentNavigator
 
 /**
  * Helper functions for navigating.
@@ -21,7 +20,7 @@ fun Navigator.navigate(navController: NavController, destination: NavDirections)
 /**
  * Same as [navigate] but supports extras for shared element transitions.
  */
-fun Navigator.navigate(navController: NavController, destination: NavDirections , extras: FragmentNavigator.Extras) = with(
+fun Navigator.navigate(navController: NavController, destination: NavDirections , extras: androidx.navigation.Navigator.Extras) = with(
     navController) {
     currentDestination?.getAction(destination.actionId)
         ?.let { navigate(destination.actionId, destination.arguments , null ,extras) }

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingNavigator.kt
@@ -1,6 +1,8 @@
 package com.asfoundation.wallet.onboarding
 
+import android.content.Intent
 import androidx.fragment.app.Fragment
+import androidx.navigation.ActivityNavigator
 import androidx.navigation.fragment.findNavController
 import com.asfoundation.wallet.base.Navigator
 import com.asfoundation.wallet.base.navigate
@@ -9,17 +11,31 @@ import javax.inject.Inject
 class OnboardingNavigator @Inject constructor(private val fragment: Fragment) : Navigator {
 
   fun navigateToTermsBottomSheet() {
-    navigate(fragment.findNavController(),
-        OnboardingFragmentDirections.actionNavigateTermsConditions())
+    navigate(
+      fragment.findNavController(),
+      OnboardingFragmentDirections.actionNavigateTermsConditions()
+    )
   }
 
+  //when navigation component doesn't have this limitation anymore, this extras should be removed
   fun navigateToMainActivity(fromSupportNotification: Boolean) {
-    navigate(fragment.findNavController(),
-        OnboardingFragmentDirections.actionNavigateToMainActivity(fromSupportNotification))
+    val clearBackStackExtras = ActivityNavigator.Extras.Builder()
+      .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+      .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      .build()
+
+    navigate(
+      fragment.findNavController(),
+      OnboardingFragmentDirections.actionNavigateToMainActivity(fromSupportNotification),
+      extras = clearBackStackExtras
+    )
   }
 
   fun navigateToRecoverActivity() {
-    navigate(fragment.findNavController(),
-        OnboardingFragmentDirections.actionNavigateToRecoverWalletActivity(onboardingLayout = true))
+    navigate(
+      fragment.findNavController(),
+      OnboardingFragmentDirections.actionNavigateToRecoverWalletActivity(onboardingLayout = true)
+    )
   }
 }

--- a/app/src/main/res/navigation/onboarding_graph.xml
+++ b/app/src/main/res/navigation/onboarding_graph.xml
@@ -18,11 +18,10 @@
         android:id="@+id/action_navigate_terms_conditions"
         app:destination="@id/onboarding_terms_conditions_dialog" />
 
+    <!-- removed the 'popUpTo' because backstack wasn't being cleared when navigating to home -->
     <action
         android:id="@+id/action_navigate_to_main_activity"
-        app:destination="@id/main_activity"
-        app:popUpTo="@+id/main_nav_graph"
-        app:popUpToInclusive="true" />
+        app:destination="@id/main_activity"/>
   </fragment>
 
   <dialog


### PR DESCRIPTION
**What does this PR do?**

   Prevents a user coming from the onboarding, to go back to it after entering home
   When a user reaches home, pressing back should close the app

**Database changed?**

   No

**How should this be manually tested?**

   - Install the wallet, with all app data cleared
   - go through the onboarding flow
   - once the home appears, try to go back

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3122

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
