### PR TITLE
[hotfix-Recover] fix navigation recover to home after changing fragments

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
@@ -49,6 +49,10 @@ class RecoverEntryFragment : BasePageViewFragment(),
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     createLaunchers()
+  }
+
+  override fun onResume() {
+    super.onResume()
     handleFragmentResult()
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/recover/password/RecoverPasswordFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/password/RecoverPasswordFragment.kt
@@ -29,8 +29,8 @@ class RecoverPasswordFragment : BasePageViewFragment(),
   private val viewModel: RecoverPasswordViewModel by viewModels()
   private val views by viewBinding(RecoverPasswordFragmentBinding::bind)
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
+  override fun onResume() {
+    super.onResume()
     handleFragmentResult()
   }
 

--- a/app/src/main/res/navigation/recover_wallet_graph.xml
+++ b/app/src/main/res/navigation/recover_wallet_graph.xml
@@ -46,9 +46,7 @@
         app:argType="string" />
     <action
         android:id="@+id/action_navigate_create_wallet_dialog"
-        app:destination="@id/create_wallet_dialog_fragment"
-        app:popUpTo="@+id/onboarding_terms_conditions_dialog"
-        app:popUpToInclusive="true" />
+        app:destination="@id/create_wallet_dialog_fragment" />
 
     <action
         android:id="@+id/action_navigate_to_main_activity"


### PR DESCRIPTION
**What does this PR do?**

   When trying to recover a wallet with password and pressing back, an attempt without password would not trigger the navigation to the home.
  This was caused because the FragmentResult was being handle in the OnCreate, so pressing back would mean that the FragmentResult was not being handled anymore even though the result was being sent correctly.

**Database changed?**

   No

**How should this be manually tested?**

  - Begin the recover process with a wallet with password
  - Press back after the screen with the password appears
  - Begin to recover a wallet the DOESN'T require password
  - After the animation, the user should be redirected to the HomeFragment (this was the problem)

**What are the relevant tickets?**

  N/A

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
