### PR TITLE
[bugfix/APPC-3122] Clear backstack fix, from the recover screen

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
@@ -7,10 +7,10 @@ import android.os.Build
 import android.provider.DocumentsContract
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
+import androidx.navigation.ActivityNavigator
 import androidx.navigation.fragment.findNavController
 import com.asfoundation.wallet.base.Navigator
 import com.asfoundation.wallet.base.navigate
-import com.asfoundation.wallet.onboarding.OnboardingFragmentDirections
 import javax.inject.Inject
 
 class RecoverEntryNavigator @Inject constructor(val fragment: Fragment) : Navigator {
@@ -59,10 +59,18 @@ class RecoverEntryNavigator @Inject constructor(val fragment: Fragment) : Naviga
     fragment.requireActivity().finish()
   }
 
+  //when navigation component doesn't have this limitation anymore, this extras should be removed and this should work with popUpTo
   fun navigateToMainActivity(fromSupportNotification: Boolean) {
+    val clearBackStackExtras = ActivityNavigator.Extras.Builder()
+      .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+      .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      .build()
+
     navigate(
       fragment.findNavController(),
-      OnboardingFragmentDirections.actionNavigateToMainActivity(fromSupportNotification)
+      RecoverEntryFragmentDirections.actionNavigateToMainActivity(fromSupportNotification),
+      extras = clearBackStackExtras
     )
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/recover/password/RecoverPasswordNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/password/RecoverPasswordNavigator.kt
@@ -1,10 +1,11 @@
 package com.asfoundation.wallet.recover.password
 
+import android.content.Intent
 import androidx.fragment.app.Fragment
+import androidx.navigation.ActivityNavigator
 import androidx.navigation.fragment.findNavController
 import com.asfoundation.wallet.base.Navigator
 import com.asfoundation.wallet.base.navigate
-import com.asfoundation.wallet.onboarding.OnboardingFragmentDirections
 import javax.inject.Inject
 
 class RecoverPasswordNavigator @Inject constructor(val fragment: Fragment) : Navigator {
@@ -20,10 +21,18 @@ class RecoverPasswordNavigator @Inject constructor(val fragment: Fragment) : Nav
     fragment.findNavController().popBackStack()
   }
 
+  //when navigation component doesn't have this limitation anymore, this extras should be removed and this should work with popUpTo
   fun navigateToMainActivity(fromSupportNotification: Boolean) {
+    val clearBackStackExtras = ActivityNavigator.Extras.Builder()
+      .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+      .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      .build()
+
     navigate(
       fragment.findNavController(),
-      OnboardingFragmentDirections.actionNavigateToMainActivity(fromSupportNotification)
+      RecoverPasswordFragmentDirections.actionNavigateToMainActivity(fromSupportNotification),
+      extras = clearBackStackExtras
     )
   }
 }

--- a/app/src/main/res/navigation/recover_wallet_graph.xml
+++ b/app/src/main/res/navigation/recover_wallet_graph.xml
@@ -20,15 +20,11 @@
 
     <action
         android:id="@+id/action_navigate_create_wallet_dialog"
-        app:destination="@id/create_wallet_dialog_fragment"
-        app:popUpTo="@+id/onboarding_terms_conditions_dialog"
-        app:popUpToInclusive="true" />
+        app:destination="@id/create_wallet_dialog_fragment" />
 
     <action
         android:id="@+id/action_navigate_to_main_activity"
-        app:destination="@id/main_activity"
-        app:popUpTo="@+id/main_nav_graph"
-        app:popUpToInclusive="true" />
+        app:destination="@id/main_activity" />
   </fragment>
 
   <fragment
@@ -50,19 +46,17 @@
 
     <action
         android:id="@+id/action_navigate_to_main_activity"
-        app:destination="@id/main_activity"
-        app:popUpTo="@+id/main_nav_graph"
-        app:popUpToInclusive="true" />
+        app:destination="@id/main_activity" />
   </fragment>
 
   <dialog
       android:id="@+id/create_wallet_dialog_fragment"
       android:name="com.asfoundation.wallet.my_wallets.create_wallet.CreateWalletDialogFragment"
-      tools:layout="@layout/fragment_create_wallet_dialog_layout" >
+      tools:layout="@layout/fragment_create_wallet_dialog_layout">
     <!-- temporary argument to differentiate the recover from a creation -->
     <argument
-      android:name="needs_wallet_creation"
-      app:argType="boolean" />
+        android:name="needs_wallet_creation"
+        app:argType="boolean" />
   </dialog>
 
   <activity


### PR DESCRIPTION
**What does this PR do?**

   related to https://github.com/Catappult/appcoins-wallet-android/pull/312
   From the onboarding creating was working, but from the recover the user could still go back
   Its a temporary solution to add flags like that, in the future with improvements in the multiple back stack from the navigation component, this should be changes

**Database changed?**

   Yes | No

**How should this be manually tested?**

- Install the wallet, with all app data cleared
- go through the onboarding flow
- recover a wallet instead of creating one
- once the home appears, try to go back

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3122

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
