### PR TITLE
[release/hotfix] fixes already added invalid promo codes

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/promo_code/repository/PromoCodeRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/repository/PromoCodeRepository.kt
@@ -32,6 +32,20 @@ class PromoCodeRepository @Inject constructor(
           PromoCode(it.code, it.bonus, it.expiryDate, it.expired, it.appName)
         )
       }
+      .doOnError {
+        promoCodeLocalDataSource.savePromoCode(
+          PromoCodeResponse(
+            promoCodeString,
+            null,
+            expired = true
+          ),
+          PromoCodeBonusResponse(
+            promoCodeString,
+            null,
+            PromoCodeBonusResponse.App(null, null, null)
+          )
+        ).subscribe()
+      }
       .ignoreElement()
       .subscribeOn(rxSchedulers.io)
   }

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/GetUpdatedPromoCodeUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/GetUpdatedPromoCodeUseCase.kt
@@ -2,7 +2,6 @@ package com.asfoundation.wallet.promo_code.use_cases
 
 import com.asfoundation.wallet.promo_code.repository.PromoCode
 import com.asfoundation.wallet.promo_code.repository.PromoCodeRepository
-import io.reactivex.Observable
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -21,6 +20,9 @@ class GetUpdatedPromoCodeUseCase @Inject constructor(
           }
         }
         return@flatMap Single.just(promoCode)
+      }
+      .onErrorReturn {
+        return@onErrorReturn PromoCode(null, null, null, null, null)
       }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/ObservePromoCodeUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/ObservePromoCodeUseCase.kt
@@ -3,7 +3,6 @@ package com.asfoundation.wallet.promo_code.use_cases
 import com.asfoundation.wallet.promo_code.repository.PromoCode
 import com.asfoundation.wallet.promo_code.repository.PromoCodeRepository
 import io.reactivex.Observable
-import io.reactivex.Single
 import javax.inject.Inject
 
 class ObservePromoCodeUseCase @Inject constructor(

--- a/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/settings/entry/SettingsPresenter.kt
@@ -185,7 +185,7 @@ class SettingsPresenter(
     navigator.navigateToWithdrawScreen()
   }
 
-  fun setCurrencyPreference() {
+  private fun setCurrencyPreference() {
     disposables.add(getChangeFiatCurrencyModelUseCase()
       .observeOn(viewScheduler)
       .doOnSuccess {
@@ -200,7 +200,7 @@ class SettingsPresenter(
       .subscribe())
   }
 
-  fun setPromoCodeState() {
+  private fun setPromoCodeState() {
     disposables.add(getUpdatedPromoCodeUseCase()
       .flatMapObservable { observePromoCodeUseCase() }
       .observeOn(viewScheduler)


### PR DESCRIPTION
**What does this PR do?**

   promo codes that were already added, if they were renamed, the old ones became invalid and the would prevent the user from opening the bottom sheet

**Database changed?**

   No

**How should this be manually tested?**

- add a promo code
- edit the database with database inspection to a random invalid string
- check that the code in the database changed and is now expired
- the user can remove or delete the current old code

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
