### PR TITLE
[bugfix/APPC-3119] Promo codes message fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/promo_code/PromoCodeResult.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/PromoCodeResult.kt
@@ -1,4 +1,4 @@
-package com.asfoundation.wallet.promo_code.bottom_sheet
+package com.asfoundation.wallet.promo_code
 
 import com.asfoundation.wallet.promo_code.repository.PromoCode
 import io.reactivex.Observable
@@ -18,7 +18,7 @@ class PromoCodeMapper {
   fun map(promoCode: PromoCode): Observable<PromoCodeResult> {
     return when (promoCode.expired) {
       false -> {
-        (Observable.just(SuccessfulPromoCode(promoCode)))
+        Observable.just(SuccessfulPromoCode(promoCode))
       }
       true -> {
         Observable.just(FailedPromoCode.ExpiredCode())

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
@@ -15,10 +15,10 @@ import com.asf.wallet.R
 import com.asf.wallet.databinding.SettingsPromoCodeBottomSheetLayoutBinding
 import com.asfoundation.wallet.base.Async
 import com.asfoundation.wallet.base.SingleStateFragment
-import com.asfoundation.wallet.promo_code.bottom_sheet.FailedPromoCode
+import com.asfoundation.wallet.promo_code.FailedPromoCode
 import com.asfoundation.wallet.promo_code.bottom_sheet.PromoCodeBottomSheetNavigator
-import com.asfoundation.wallet.promo_code.bottom_sheet.PromoCodeResult
-import com.asfoundation.wallet.promo_code.bottom_sheet.SuccessfulPromoCode
+import com.asfoundation.wallet.promo_code.PromoCodeResult
+import com.asfoundation.wallet.promo_code.SuccessfulPromoCode
 import com.asfoundation.wallet.ui.common.WalletTextFieldView
 import com.asfoundation.wallet.util.KeyboardUtils
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -70,7 +70,7 @@ class PromoCodeBottomSheetFragment : BottomSheetDialogFragment(),
 
   private fun setListeners() {
     views.promoCodeBottomSheetSubmitButton.setOnClickListener {
-      viewModel.submitClick(views.promoCodeBottomSheetString.getText())
+      viewModel.submitClick(views.promoCodeBottomSheetString.getText().trim())
     }
     views.promoCodeBottomSheetReplaceButton.setOnClickListener {
       viewModel.replaceClick()
@@ -96,7 +96,7 @@ class PromoCodeBottomSheetFragment : BottomSheetDialogFragment(),
         }
       }
       is Async.Fail -> {
-        handleErrorState(FailedPromoCode.GenericError(clickAsync.error.throwable))
+        handleErrorState(FailedPromoCode.InvalidCode(clickAsync.error.throwable))
       }
       is Async.Success -> {
         state.promoCodeAsync.value?.let { handleClickSuccessState(it) }

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetViewModel.kt
@@ -4,8 +4,8 @@ import com.asfoundation.wallet.base.Async
 import com.asfoundation.wallet.base.BaseViewModel
 import com.asfoundation.wallet.base.SideEffect
 import com.asfoundation.wallet.base.ViewState
-import com.asfoundation.wallet.promo_code.bottom_sheet.FailedPromoCode
-import com.asfoundation.wallet.promo_code.bottom_sheet.PromoCodeResult
+import com.asfoundation.wallet.promo_code.FailedPromoCode
+import com.asfoundation.wallet.promo_code.PromoCodeResult
 import com.asfoundation.wallet.promo_code.use_cases.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/ObservePromoCodeResultUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/use_cases/ObservePromoCodeResultUseCase.kt
@@ -1,7 +1,7 @@
 package com.asfoundation.wallet.promo_code.use_cases
 
-import com.asfoundation.wallet.promo_code.bottom_sheet.PromoCodeMapper
-import com.asfoundation.wallet.promo_code.bottom_sheet.PromoCodeResult
+import com.asfoundation.wallet.promo_code.PromoCodeMapper
+import com.asfoundation.wallet.promo_code.PromoCodeResult
 import com.asfoundation.wallet.promo_code.repository.PromoCodeRepository
 import io.reactivex.Observable
 import javax.inject.Inject

--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
@@ -69,7 +69,7 @@ class RecoverEntryFragment : BasePageViewFragment(),
     }
     views.recoverWalletButton.setOnClickListener {
       viewModel.handleRecoverClick(
-        views.recoverWalletOptions.recoverKeystoreInput.getText()
+        views.recoverWalletOptions.recoverKeystoreInput.getText().trim()
       )
     }
     viewModel.collectStateAndEvents(lifecycle, viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/com/asfoundation/wallet/redeem_gift/bottom_sheet/RedeemGiftBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/redeem_gift/bottom_sheet/RedeemGiftBottomSheetFragment.kt
@@ -50,7 +50,7 @@ class RedeemGiftBottomSheetFragment : BottomSheetDialogFragment(),
     super.onViewCreated(view, savedInstanceState)
 
     views.redeemGiftBottomSheetSubmitButton.setOnClickListener {
-      viewModel.submitClick(views.redeemGiftBottomSheetString.text.toString())
+      viewModel.submitClick(views.redeemGiftBottomSheetString.text.toString().trim())
     }
     views.redeemGiftBottomSheetSuccessGotItButton.setOnClickListener {
       viewModel.successGotItClick()


### PR DESCRIPTION
**What does this PR do?**

   FIxes promo code error message, when a code as invalid the message was the wrong one.
   Also fixes the extra space on the text inputs that would cause problems when verifying the code with the space.
   This happened also in the redeem gift and the recover wallet text inputs

**Database changed?**

    No

**How should this be manually tested?**

 - Insert a invalid promo code, "Invalid code. Try with another one!” should appear instead of "Oops! This code couldn't be applied."
 - Insert a valid code(megapack for example) but with extra spaces in the end, it should not give problems anymore

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3119

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
