### PR TITLE
[bugfix/APPC-3288] Prevents the last wallet deletion

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/more/MoreDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/more/MoreDialogFragment.kt
@@ -53,8 +53,8 @@ class MoreDialogFragment : BottomSheetDialogFragment(),
 
   override fun onStateChanged(state: MoreDialogState) {
     val wallets = state.walletsAsync()
-    views.deleteWalletCardView.visibility =
-      if (wallets?.isEmpty() == false) View.VISIBLE else View.GONE
+    val lastWallet: Boolean = wallets?.let { it.size > 1 } == false
+    views.deleteWalletCardView.visibility = if (lastWallet) View.GONE else View.VISIBLE
     views.walletsView.apply {
       if (wallets.isNullOrEmpty()) {
         removeAllViews()


### PR DESCRIPTION
**What does this PR do?**

   Prevents the last wallet deletion, meaning that the Delete option will only appear if a user has 2 or more wallets

**How should this be manually tested?**

  - Restore multiple wallets and check that the delete option will show with 2 or more
  - Delete all wallets and check if the option disappears only in the last wallet

**What are the relevant tickets?**

  Tickets related to this pull-request: https://aptoide.atlassian.net/browse/APPC-3288

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
