### PR TITLE
[bugfix/APPC-3289] Verify card initial state

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
@@ -281,10 +281,14 @@ class MyWalletsFragment : BasePageViewFragment(),
     views.myWalletsContent.verifyWalletTitle.setText(R.string.verification_settings_verified_title)
     views.myWalletsContent.verifyWalletText.visibility = View.VISIBLE
     views.myWalletsContent.verifyWalletText.setText(R.string.mywallet_unverified_body)
-    views.myWalletsContent.verifyButton.visibility = View.VISIBLE
-    views.myWalletsContent.verifyButton.isEnabled = !disableButton
+    views.myWalletsContent.verifyButton.visibility = if (!disableButton) View.VISIBLE else View.GONE
     views.myWalletsContent.verifyButton.setText(getString(R.string.mywallet_verify_payment_method_button))
-    views.myWalletsContent.verifyButton.setColor(ContextCompat.getColor(requireContext(), R.color.white))
+    views.myWalletsContent.verifyButton.setColor(
+      ContextCompat.getColor(
+        requireContext(),
+        R.color.white
+      )
+    )
     views.myWalletsContent.verifyButton.setOnClickListener {
       navigator.navigateToVerifyPicker()
     }
@@ -299,15 +303,14 @@ class MyWalletsFragment : BasePageViewFragment(),
     views.myWalletsContent.verifyWalletTitle.setText(R.string.mywallet_unverified_title)
     views.myWalletsContent.verifyWalletText.visibility = View.VISIBLE
     views.myWalletsContent.verifyWalletText.setText(R.string.mywallet_unverified_body)
-    views.myWalletsContent.verifyButton.visibility = View.VISIBLE
-    views.myWalletsContent.verifyButton.isEnabled = !disableButton
+    views.myWalletsContent.verifyButton.visibility = if (!disableButton) View.VISIBLE else View.GONE
     views.myWalletsContent.verifyButton.setText(getString(R.string.referral_view_verify_button))
-      views.myWalletsContent.verifyButton.setColor(
-        ContextCompat.getColor(
-          requireContext(),
-          R.color.wild_watermelon
-        )
+    views.myWalletsContent.verifyButton.setColor(
+      ContextCompat.getColor(
+        requireContext(),
+        R.color.wild_watermelon
       )
+    )
     views.myWalletsContent.verifyButton.setOnClickListener {
       navigator.navigateToVerifyPicker()
     }

--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
@@ -3,7 +3,6 @@ package com.asfoundation.wallet.my_wallets.main
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.text.format.DateFormat
 import android.view.LayoutInflater

--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsFragment.kt
@@ -325,8 +325,7 @@ class MyWalletsFragment : BasePageViewFragment(),
     views.myWalletsContent.verifyWalletTitle.setText(R.string.card_verification_wallets_one_step_title)
     views.myWalletsContent.verifyWalletText.visibility = View.VISIBLE
     views.myWalletsContent.verifyWalletText.setText(R.string.card_verification_wallets_one_step_body)
-    views.myWalletsContent.verifyButton.visibility = View.VISIBLE
-    views.myWalletsContent.verifyButton.isEnabled = !disableButton
+    views.myWalletsContent.verifyButton.visibility = if (!disableButton) View.VISIBLE else View.GONE
     views.myWalletsContent.verifyButton.setText(getString(R.string.card_verification_wallets_insert_bode_button))
     views.myWalletsContent.verifyButton.setColor(
       ContextCompat.getColor(


### PR DESCRIPTION
**What does this PR do?**

   Prevents the disabled button layout to show when the button isn't ready, and just hides the button in that scenario.
  

**Where should the reviewer start?**

- MyWalletFragment.kt 

**How should this be manually tested?**

 - Inside the "More" dialog create a new wallet
 - check the verify button during the wallet creation animation, it should be hidden.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3289

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
