### PR TITLE
[bugfix/APPC-3244] Non-current wallet backup

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/backup/repository/BackupRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/repository/BackupRepository.kt
@@ -44,8 +44,8 @@ class BackupRepository @Inject constructor(
 
   private fun getDefaultBackupFileExtension() = ".bck"
 
-  fun sendBackupEmail(keystore: String, email: String): Completable {
-    return walletService.getAndSignCurrentWalletAddress()
+  fun sendBackupEmail(walletAddress: String, keystore: String, email: String): Completable {
+    return walletService.getAndSignSpecificWalletAddress(walletAddress)
         .flatMapCompletable {
           backupEmailApi.sendBackupEmail(
             it.address, it.signedAddress,

--- a/app/src/main/java/com/asfoundation/wallet/backup/repository/BackupRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/repository/BackupRepository.kt
@@ -32,7 +32,8 @@ class BackupRepository @Inject constructor(
     val outputStream = contentResolver.openOutputStream(file.uri)
     try {
       outputStream?.run { write(content.toByteArray()) } ?: return Completable.error(
-          Throwable("Null outputStream"))
+        Throwable("Null outputStream")
+      )
     } catch (e: IOException) {
       e.printStackTrace()
       return Completable.error(Throwable(e))
@@ -46,18 +47,18 @@ class BackupRepository @Inject constructor(
 
   fun sendBackupEmail(walletAddress: String, keystore: String, email: String): Completable {
     return walletService.getAndSignSpecificWalletAddress(walletAddress)
-        .flatMapCompletable {
-          backupEmailApi.sendBackupEmail(
-            it.address, it.signedAddress,
-            EmailBody(email, keystore.convertToBase64())
-          )
-        }
-        .subscribeOn(rxSchedulers.io)
+      .flatMapCompletable {
+        backupEmailApi.sendBackupEmail(
+          it.address, it.signedAddress,
+          EmailBody(email, keystore.convertToBase64())
+        )
+      }
+      .subscribeOn(rxSchedulers.io)
   }
 
   fun logBackupSuccess(ewt: String): Completable {
     return backupLogApi.logBackupSuccess(ewt)
-        .subscribeOn(rxSchedulers.io)
+      .subscribeOn(rxSchedulers.io)
   }
 
   interface BackupEmailApi {
@@ -72,6 +73,7 @@ class BackupRepository @Inject constructor(
   interface BackupLogApi {
     @POST("/transaction/wallet/backup/")
     fun logBackupSuccess(
-        @Header("authorization") authorization: String): Completable
+      @Header("authorization") authorization: String
+    ): Completable
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/backup/use_cases/SendBackupToEmailUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/use_cases/SendBackupToEmailUseCase.kt
@@ -15,6 +15,6 @@ class SendBackupToEmailUseCase @Inject constructor(
     email: String
   ): Completable {
     return createBackupUseCase(walletAddress, password)
-      .flatMapCompletable { backupRepository.sendBackupEmail(it, email) }
+      .flatMapCompletable { backupRepository.sendBackupEmail(walletAddress, it, email) }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/service/AccountWalletService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/service/AccountWalletService.kt
@@ -50,6 +50,12 @@ class AccountWalletService @Inject constructor(
   override fun signContent(content: String): Single<String> = find()
     .flatMap { wallet -> getPrivateKey(wallet).map { sign(normalizer.normalize(content), it) } }
 
+  override fun signSpecificWalletAddressContent(
+    walletAddress: String,
+    content: String
+  ): Single<String> = walletRepository.findWallet(walletAddress)
+    .flatMap { wallet -> getPrivateKey(wallet).map { sign(normalizer.normalize(content), it) } }
+
   override fun getAndSignCurrentWalletAddress(): Single<WalletAddressModel> = find()
     .flatMap { wallet ->
       getPrivateKey(wallet)

--- a/app/src/main/java/com/asfoundation/wallet/service/AccountWalletService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/service/AccountWalletService.kt
@@ -57,6 +57,14 @@ class AccountWalletService @Inject constructor(
         .map { WalletAddressModel(wallet.address, it) }
     }
 
+  override fun getAndSignSpecificWalletAddress(walletAddress: String): Single<WalletAddressModel> =
+    walletRepository.findWallet(walletAddress)
+      .flatMap { wallet ->
+        getPrivateKey(wallet)
+          .map { sign(normalizer.normalize(toChecksumAddress(wallet.address)), it) }
+          .map { WalletAddressModel(wallet.address, it) }
+      }
+
   @Throws(Exception::class)
   private fun sign(plainText: String, ecKey: ECKey): String =
     ecKey.sign(sha3(plainText.toByteArray())).toHex()

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/WalletService.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/WalletService.kt
@@ -14,4 +14,6 @@ interface WalletService {
   fun signContent(content: String): Single<String>
 
   fun getAndSignCurrentWalletAddress(): Single<WalletAddressModel>
+
+  fun getAndSignSpecificWalletAddress(walletAddress :String): Single<WalletAddressModel>
 }

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/WalletService.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/WalletService.kt
@@ -13,6 +13,8 @@ interface WalletService {
 
   fun signContent(content: String): Single<String>
 
+  fun signSpecificWalletAddressContent(walletAddress: String, content: String): Single<String>
+
   fun getAndSignCurrentWalletAddress(): Single<WalletAddressModel>
 
   fun getAndSignSpecificWalletAddress(walletAddress :String): Single<WalletAddressModel>

--- a/bdsbilling/src/test/java/com/appcoins/wallet/bdsbilling/BillingPaymentProofSubmissionTest.kt
+++ b/bdsbilling/src/test/java/com/appcoins/wallet/bdsbilling/BillingPaymentProofSubmissionTest.kt
@@ -65,7 +65,15 @@ class BillingPaymentProofSubmissionTest {
       .setWalletService(object : WalletService {
         override fun getWalletAddress(): Single<String> = Single.just(walletAddress)
         override fun signContent(content: String): Single<String> = Single.just(signedContent)
+        override fun signSpecificWalletAddressContent(
+          walletAddress: String,
+          content: String
+        ): Single<String> = Single.just(signedContent)
+
         override fun getAndSignCurrentWalletAddress(): Single<WalletAddressModel> =
+          Single.just(WalletAddressModel(walletAddress, signedContent))
+
+        override fun getAndSignSpecificWalletAddress(walletAddress: String): Single<WalletAddressModel> =
           Single.just(WalletAddressModel(walletAddress, signedContent))
 
         override fun getWalletOrCreate(): Single<String> = Single.just(walletAddress)


### PR DESCRIPTION
**What does this PR do?**

   Fixes the problem when a user has multiple wallets and tries to backup a non-active wallet.

**Where should the reviewer start?**

- AccountWalletService.kt

**How should this be manually tested?**

- Create new wallets (2 or more)
- Backup the active wallet to check the flow
- Backup a non-active wallet via email
- Backup a non-active wallet via file
- Check if in both non-active cases, the backup was sucessful (check the file or text and try to recover)
- Check that the backend now was the backup information (wallet info endpoint) for that wallet

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3244

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
