### PR TITLE
[bugfix/APPC-3323] Fix wallet name for password recover

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/entity/WalletKeyStore.kt
+++ b/app/src/main/java/com/asfoundation/wallet/entity/WalletKeyStore.kt
@@ -1,3 +1,5 @@
 package com.asfoundation.wallet.entity
 
-data class WalletKeyStore(val name: String?, val contents: String)
+import java.io.Serializable
+
+data class WalletKeyStore(val name: String?, val contents: String) : Serializable

--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
@@ -139,7 +139,7 @@ class RecoverEntryFragment : BasePageViewFragment(),
       }
       is FailedEntryRecover.InvalidPassword -> {
         navigator.navigateToRecoverPasswordFragment(
-          keystore = recoverResult.key,
+          keystore = recoverResult.keyStore,
           walletBalance = recoverResult.symbol + recoverResult.amount,
           walletAddress = recoverResult.address
         )

--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.asfoundation.wallet.base.Navigator
 import com.asfoundation.wallet.base.navigate
+import com.asfoundation.wallet.entity.WalletKeyStore
 import com.asfoundation.wallet.recover.RecoverActivity
 import javax.inject.Inject
 
@@ -34,7 +35,7 @@ class RecoverEntryNavigator @Inject constructor(val fragment: Fragment) : Naviga
   }
 
   fun navigateToRecoverPasswordFragment(
-    keystore: String,
+    keystore: WalletKeyStore,
     walletBalance: String,
     walletAddress: String
   ) {

--- a/app/src/main/java/com/asfoundation/wallet/recover/result/RecoverEntryResult.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/result/RecoverEntryResult.kt
@@ -13,7 +13,7 @@ sealed class FailedEntryRecover : RecoverEntryResult() {
   data class GenericError(val throwable: Throwable? = null) : FailedEntryRecover()
   data class InvalidPassword(
     val throwable: Throwable? = null,
-    val key: String,
+    val keyStore: WalletKeyStore,
     val address: String,
     val amount: String,
     val symbol: String
@@ -46,7 +46,7 @@ class RecoverEntryResultMapper(
       .map {
         FailedEntryRecover.InvalidPassword(
           throwable = restoreResult.throwable,
-          key = walletKeyStore.contents,
+          keyStore = walletKeyStore,
           address = it.wallet,
           amount = currencyFormatUtils.formatCurrency(it.walletBalance.overallFiat.amount),
           symbol = it.walletBalance.overallFiat.symbol

--- a/app/src/main/java/com/asfoundation/wallet/recover/result/RecoverPasswordResult.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/result/RecoverPasswordResult.kt
@@ -1,17 +1,21 @@
 package com.asfoundation.wallet.recover.result
 
+import com.asfoundation.wallet.entity.WalletKeyStore
 import io.reactivex.Single
 
 sealed class RecoverPasswordResult
 
-data class SuccessfulPasswordRecover(val address: String) : RecoverPasswordResult()
+data class SuccessfulPasswordRecover(val address: String, val name: String?) :
+  RecoverPasswordResult()
 
 sealed class FailedPasswordRecover : RecoverPasswordResult() {
   data class GenericError(val throwable: Throwable? = null) : FailedPasswordRecover()
   data class InvalidPassword(val throwable: Throwable? = null) : FailedPasswordRecover()
 }
 
-class RecoverPasswordResultMapper() {
+class RecoverPasswordResultMapper(
+  private val walletKeyStore: WalletKeyStore
+) {
   fun map(restoreResult: RestoreResult): Single<RecoverPasswordResult> {
     return when (restoreResult) {
       is FailedRestore.GenericError ->
@@ -19,7 +23,7 @@ class RecoverPasswordResultMapper() {
       is FailedRestore.InvalidPassword ->
         Single.just(FailedPasswordRecover.InvalidPassword(restoreResult.throwable))
       is SuccessfulRestore ->
-        Single.just(SuccessfulPasswordRecover(restoreResult.address))
+        Single.just(SuccessfulPasswordRecover(restoreResult.address, walletKeyStore.name))
       else -> TODO()
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/recover/use_cases/RecoverPasswordKeystoreUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/use_cases/RecoverPasswordKeystoreUseCase.kt
@@ -1,7 +1,8 @@
 package com.asfoundation.wallet.recover.use_cases
 
-import com.asfoundation.wallet.recover.result.*
-import com.asfoundation.wallet.repository.BackupRestorePreferencesRepository
+import com.asfoundation.wallet.entity.WalletKeyStore
+import com.asfoundation.wallet.recover.result.RecoverPasswordResult
+import com.asfoundation.wallet.recover.result.RecoverPasswordResultMapper
 import com.asfoundation.wallet.repository.PasswordStore
 import com.asfoundation.wallet.repository.WalletRepositoryType
 import io.reactivex.Single
@@ -12,13 +13,16 @@ class RecoverPasswordKeystoreUseCase @Inject constructor(
   private val passwordStore: PasswordStore,
 ) {
 
-  operator fun invoke(keystore: String, password: String = ""): Single<RecoverPasswordResult> {
+  operator fun invoke(
+    keyStore: WalletKeyStore,
+    password: String = ""
+  ): Single<RecoverPasswordResult> {
     return passwordStore.generatePassword()
       .flatMap { newPassword ->
-        walletRepository.restoreKeystoreToWallet(keystore, password, newPassword)
+        walletRepository.restoreKeystoreToWallet(keyStore.contents, password, newPassword)
       }
       .flatMap {
-        RecoverPasswordResultMapper().map(it)
+        RecoverPasswordResultMapper(keyStore).map(it)
       }
   }
 }

--- a/app/src/main/res/navigation/recover_wallet_graph.xml
+++ b/app/src/main/res/navigation/recover_wallet_graph.xml
@@ -35,7 +35,7 @@
       tools:layout="@layout/recover_password_fragment">
     <argument
         android:name="keystore"
-        app:argType="string" />
+        app:argType="com.asfoundation.wallet.entity.WalletKeyStore" />
     <argument
         android:name="wallet_balance"
         app:argType="string" />


### PR DESCRIPTION
**What does this PR do?**

   It was only possible to have the name if the recover was not with password. This PR fixes the recover name when recovering a wallet that is protected by password. 

**Database changed?**

   No

**Where should the reviewer start?**

- RecoverPasswordVIewModel.kt

**How should this be manually tested?**

  - Recover a wallet that is password protected with a file
  - check if tha name of the file now is the name of the wallet
 
**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3323

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
