### PR TITLE
[APPC-3335] Add 5 seconds timeout on the install referrer retrieval

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/app_start/FirstUtm.kt
+++ b/app/src/main/java/com/asfoundation/wallet/app_start/FirstUtm.kt
@@ -1,6 +1,7 @@
 package com.asfoundation.wallet.app_start
 
 import it.czerwinski.android.hilt.annotations.BoundTo
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.URLDecoder
 import javax.inject.Inject
 
@@ -13,7 +14,8 @@ class FirstUtmUseCaseImpl @Inject constructor(
   private val repository: FirstUtmRepository
 ) : FirstUtmUseCase {
   override suspend operator fun invoke(): StartMode.FirstUtm? {
-    val referrer = repository.getReferrerUrl()?.splitQuery()
+    val referrer = withTimeoutOrNull(5000) { repository.getReferrerUrl() }
+      ?.splitQuery()
     return if (referrer.isCorrectUtm()) {
       StartMode.FirstUtm(
         sku = referrer?.get(UTM_CONTENT)?.get(0) ?: "",

--- a/app/src/main/java/com/asfoundation/wallet/app_start/Repositories.kt
+++ b/app/src/main/java/com/asfoundation/wallet/app_start/Repositories.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.suspendCoroutine
 
 @BoundTo(supertype = AppStartRepository::class)
 class AppStartRepositoryImpl @Inject constructor(
-  @ApplicationContext val context: Context,
+  @ApplicationContext private val context: Context,
   private val packageManager: PackageManager,
   private val pref: SharedPreferences
 ) : AppStartRepository {
@@ -34,7 +34,7 @@ class AppStartRepositoryImpl @Inject constructor(
 
 @BoundTo(supertype = FirstUtmRepository::class)
 class FirstUtmRepositoryImpl @Inject constructor(
-  @ApplicationContext val context: Context,
+  @ApplicationContext private val context: Context,
 ) : FirstUtmRepository {
 
   private val referrerClient: InstallReferrerClient by lazy {

--- a/app/src/main/java/com/asfoundation/wallet/app_start/Repositories.kt
+++ b/app/src/main/java/com/asfoundation/wallet/app_start/Repositories.kt
@@ -9,8 +9,8 @@ import com.asf.wallet.BuildConfig
 import com.asfoundation.wallet.app_start.AppStartRepository.Companion.RUNS_COUNT
 import dagger.hilt.android.qualifiers.ApplicationContext
 import it.czerwinski.android.hilt.annotations.BoundTo
+import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
-import kotlin.coroutines.suspendCoroutine
 
 @BoundTo(supertype = AppStartRepository::class)
 class AppStartRepositoryImpl @Inject constructor(
@@ -43,7 +43,7 @@ class FirstUtmRepositoryImpl @Inject constructor(
     ).build()
   }
 
-  override suspend fun getReferrerUrl(): String? = suspendCoroutine { cont ->
+  override suspend fun getReferrerUrl(): String? = suspendCancellableCoroutine { cont ->
     referrerClient.startConnection(object : InstallReferrerStateListener {
       override fun onInstallReferrerSetupFinished(responseCode: Int) {
         val referrerUrl = if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
@@ -51,7 +51,8 @@ class FirstUtmRepositoryImpl @Inject constructor(
         } else {
           null
         }
-        cont.resumeWith(Result.success(referrerUrl))
+        if (cont.isActive)
+          cont.resumeWith(Result.success(referrerUrl))
         referrerClient.endConnection()
       }
 

--- a/app/src/test/java/com/asfoundation/wallet/app_start/FirstTopAppUseCaseTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/app_start/FirstTopAppUseCaseTest.kt
@@ -20,7 +20,7 @@ import kotlin.streams.toList
 internal class FirstTopAppUseCaseTest {
 
   @Test
-  fun `On system without top apps returns null`() = coScenario { _ ->
+  fun `On system without top apps returns null`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 
@@ -36,7 +36,7 @@ internal class FirstTopAppUseCaseTest {
   }
 
   @Test
-  fun `On system with 1 top app returns FirstTopApp`() = coScenario { _ ->
+  fun `On system with 1 top app returns FirstTopApp`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 
@@ -55,7 +55,7 @@ internal class FirstTopAppUseCaseTest {
   }
 
   @Test
-  fun `On system with 2 top apps returns null`() = coScenario { _ ->
+  fun `On system with 2 top apps returns null`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 
@@ -73,7 +73,7 @@ internal class FirstTopAppUseCaseTest {
   }
 
   @Test
-  fun `On system with 3 top apps returns null`() = coScenario { _ ->
+  fun `On system with 3 top apps returns null`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 
@@ -91,7 +91,7 @@ internal class FirstTopAppUseCaseTest {
   }
 
   @Test
-  fun `On system with 4 top apps returns null`() = coScenario { _ ->
+  fun `On system with 4 top apps returns null`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 
@@ -114,7 +114,7 @@ internal class FirstTopAppUseCaseTest {
   }
 
   @Test
-  fun `On system with all top apps returns null`() = coScenario { _ ->
+  fun `On system with all top apps returns null`() = coScenario {
     val repository: FirstTopAppRepository
     val useCase: FirstTopAppUseCase
 

--- a/app/src/test/java/com/asfoundation/wallet/app_start/FirstUtmUseCaseTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/app_start/FirstUtmUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.asfoundation.wallet.app_start
 
 import com.asfoundation.wallet.gherkin.coScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -23,6 +24,27 @@ internal class FirstUtmUseCaseTest {
     m Given "Repository returns null UTM"
     repository = object : FirstUtmRepository {
       override suspend fun getReferrerUrl(): String? = null
+    }
+    useCase = FirstUtmUseCaseImpl(repository)
+
+    m When "Use case called for result"
+    val result = useCase()
+
+    m Then "result is null"
+    assertNull(result)
+  }
+
+  @Test
+  fun `OSP UTM after 5 seconds returns null`() = coScenario {
+    val repository: FirstUtmRepository
+    val useCase: FirstUtmUseCase
+
+    m Given "Repository returns OSP UTM after 5 seconds"
+    repository = object : FirstUtmRepository {
+      override suspend fun getReferrerUrl(): String {
+        delay(5000)
+        return UTM_OSP
+      }
     }
     useCase = FirstUtmUseCaseImpl(repository)
 

--- a/app/src/test/java/com/asfoundation/wallet/app_start/FirstUtmUseCaseTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/app_start/FirstUtmUseCaseTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 internal class FirstUtmUseCaseTest {
 
   @Test
-  fun `No UTM returns null`() = coScenario { _ ->
+  fun `No UTM returns null`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 
@@ -34,7 +34,7 @@ internal class FirstUtmUseCaseTest {
   }
 
   @Test
-  fun `OSP UTM returns FirstUtm`() = coScenario { _ ->
+  fun `OSP UTM returns FirstUtm`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 
@@ -60,7 +60,7 @@ internal class FirstUtmUseCaseTest {
   }
 
   @Test
-  fun `SDK UTM returns FirstUtm`() = coScenario { _ ->
+  fun `SDK UTM returns FirstUtm`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 
@@ -87,7 +87,7 @@ internal class FirstUtmUseCaseTest {
   }
 
   @Test
-  fun `Wrong term UTM returns null`() = coScenario { _ ->
+  fun `Wrong term UTM returns null`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 
@@ -106,7 +106,7 @@ internal class FirstUtmUseCaseTest {
   }
 
   @Test
-  fun `UTM without medium returns null`() = coScenario { _ ->
+  fun `UTM without medium returns null`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 
@@ -125,7 +125,7 @@ internal class FirstUtmUseCaseTest {
   }
 
   @Test
-  fun `Invalid UTM returns null`() = coScenario { _ ->
+  fun `Invalid UTM returns null`() = coScenario {
     val repository: FirstUtmRepository
     val useCase: FirstUtmUseCase
 


### PR DESCRIPTION
**What does this PR do?**

   Add 5 seconds timeout in case if install referrer will never invoke a callback.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] app/src/main/java/com/asfoundation/wallet/app_start/Repositories.kt
- [ ] app/src/test/java/com/asfoundation/wallet/app_start/FirstUtmUseCaseTest.kt
- [ ] app/src/main/java/com/asfoundation/wallet/app_start/FirstUtm.kt

**How should this be manually tested?**

  No reliable way to test.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3335](https://aptoide.atlassian.net/browse/APPC-3335)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
