### PR TITLE
[bugfix/APPC-3345] VIP callouts not working

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
@@ -58,6 +58,11 @@ class NavBarFragment : BasePageViewFragment(),
     setVipCalloutClickListener()
   }
 
+  override fun onResume() {
+    super.onResume()
+    viewModel.handleVipCallout()
+  }
+
   private fun initHostFragments() {
     navHostFragment = childFragmentManager.findFragmentById(
       R.id.nav_host_container
@@ -69,7 +74,7 @@ class NavBarFragment : BasePageViewFragment(),
 
   override fun onStateChanged(state: NavBarState) {
     setPromotionBadge(state.showPromotionsBadge)
-    setVipCallout(state.showVipCallout)
+    setVipCallout(state.shouldShowVipCallout)
   }
 
   override fun onSideEffect(sideEffect: NavBarSideEffect) {
@@ -89,8 +94,8 @@ class NavBarFragment : BasePageViewFragment(),
     }
   }
 
-  private fun setVipCallout(showVipCallout: Boolean) {
-    if (showVipCallout)
+  private fun setVipCallout(shouldShowVipCallout: Boolean) {
+    if (shouldShowVipCallout)
       showVipCallout()
     else
       hideVipCallout()
@@ -136,6 +141,7 @@ class NavBarFragment : BasePageViewFragment(),
         R.id.home_graph -> {
         }
         R.id.promotions_graph -> {
+          viewModel.removePromotionsBadge()
           if (views.vipPromotionsCallout.vipCalloutLayout.isVisible) {
             hideVipCallout()
             viewModel.vipPromotionsSeen()

--- a/app/src/main/java/com/asfoundation/wallet/main/use_cases/IsNewVipUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/use_cases/IsNewVipUseCase.kt
@@ -2,25 +2,27 @@ package com.asfoundation.wallet.main.use_cases
 
 import com.appcoins.wallet.gamification.repository.PromotionsRepository
 import com.appcoins.wallet.gamification.repository.entity.GamificationStatus
-import com.asfoundation.wallet.home.usecases.FindDefaultWalletUseCase
-import io.reactivex.Single
+import com.asfoundation.wallet.home.usecases.ObserveDefaultWalletUseCase
+import io.reactivex.Observable
 import javax.inject.Inject
 
 class IsNewVipUseCase @Inject constructor(
   private val promotionsRepository: PromotionsRepository,
-  private val findDefaultWalletUseCase: FindDefaultWalletUseCase
+  private val observeDefaultWalletUseCase: ObserveDefaultWalletUseCase
 ) {
 
-  operator fun invoke(): Single<Boolean> {
-    return findDefaultWalletUseCase()
+  operator fun invoke(): Observable<Boolean> {
+    return observeDefaultWalletUseCase()
       .flatMap { wallet ->
         promotionsRepository.getGamificationStats(wallet.address, null)
+          .takeUntil {
+            it.gamificationStatus != GamificationStatus.NONE
+          }
           .map { stats ->
-            val isVipCalloutAlreadySeen = promotionsRepository.isVipCalloutAlreadySeen()
+            val isVipCalloutAlreadySeen =
+              promotionsRepository.isVipCalloutAlreadySeen(wallet.address)
             stats.gamificationStatus == GamificationStatus.VIP && !isVipCalloutAlreadySeen
           }
-          .firstOrError()
       }
   }
-
 }

--- a/app/src/main/java/com/asfoundation/wallet/main/use_cases/SetVipPromotionsSeenUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/use_cases/SetVipPromotionsSeenUseCase.kt
@@ -1,14 +1,22 @@
 package com.asfoundation.wallet.main.use_cases
 
 import com.appcoins.wallet.gamification.repository.PromotionsRepository
+import com.asfoundation.wallet.home.usecases.ObserveDefaultWalletUseCase
+import io.reactivex.Completable
+import io.reactivex.internal.operators.completable.CompletableFromAction
 import javax.inject.Inject
 
 class SetVipPromotionsSeenUseCase @Inject constructor(
-  private val promotionsRepository: PromotionsRepository
+  private val promotionsRepository: PromotionsRepository,
+  private val observeDefaultWalletUseCase: ObserveDefaultWalletUseCase
 ) {
 
-  operator fun invoke(isSeen: Boolean) {
-    promotionsRepository.setVipCalloutAlreadySeen(isSeen)
+  operator fun invoke(isSeen: Boolean): Completable {
+    return observeDefaultWalletUseCase()
+      .flatMapCompletable {
+        CompletableFromAction {
+          promotionsRepository.setVipCalloutAlreadySeen(it.address, isSeen)
+        }
+      }
   }
-
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/SharedPreferencesUserStatsLocalData.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/SharedPreferencesUserStatsLocalData.kt
@@ -263,12 +263,12 @@ class SharedPreferencesUserStatsLocalData @Inject constructor(
     return preferences.getString(WALLET_ORIGIN + wallet, "")!!
   }
 
-  override fun isVipCalloutAlreadySeen() =
-    preferences.getBoolean(VIP_CALLOUT_SEEN, false)
+  override fun isVipCalloutAlreadySeen(wallet: String) =
+    preferences.getBoolean(VIP_CALLOUT_SEEN + wallet, false)
 
-  override fun setVipCalloutAlreadySeen(isSeen: Boolean) {
+  override fun setVipCalloutAlreadySeen(wallet: String, isSeen: Boolean) {
     preferences.edit()
-      .putBoolean(VIP_CALLOUT_SEEN, isSeen)
+      .putBoolean(VIP_CALLOUT_SEEN + wallet, isSeen)
       .apply()
   }
 

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionsRepository.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/PromotionsRepository.kt
@@ -10,14 +10,19 @@ import java.math.BigDecimal
 
 interface PromotionsRepository {
 
-  fun getGamificationStats(wallet: String, promoCodeString: String?): Observable<PromotionsGamificationStats>
+  fun getGamificationStats(
+    wallet: String,
+    promoCodeString: String?
+  ): Observable<PromotionsGamificationStats>
 
   fun getGamificationLevel(wallet: String, promoCodeString: String?): Single<Int>
 
   fun getLevels(wallet: String, offlineFirst: Boolean = true): Observable<Levels>
 
-  fun getForecastBonus(wallet: String, packageName: String,
-                       amount: BigDecimal, promoCodeString: String?): Single<ForecastBonus>
+  fun getForecastBonus(
+    wallet: String, packageName: String,
+    amount: BigDecimal, promoCodeString: String?
+  ): Single<ForecastBonus>
 
   fun getLastShownLevel(wallet: String, gamificationContext: GamificationContext): Single<Int>
 
@@ -27,8 +32,10 @@ interface PromotionsRepository {
 
   fun setSeenGenericPromotion(id: String, screen: String)
 
-  fun getUserStats(wallet: String, promoCodeString: String?,
-                   offlineFirst: Boolean = true): Observable<UserStats>
+  fun getUserStats(
+    wallet: String, promoCodeString: String?,
+    offlineFirst: Boolean = true
+  ): Observable<UserStats>
 
   fun getWalletOrigin(wallet: String, promoCodeString: String?): Single<WalletOrigin>
 
@@ -38,8 +45,8 @@ interface PromotionsRepository {
 
   fun getVipReferral(wallet: String): Observable<VipReferralResponse>
 
-  fun isVipCalloutAlreadySeen(): Boolean
+  fun isVipCalloutAlreadySeen(wallet: String): Boolean
 
-  fun setVipCalloutAlreadySeen(isSeen: Boolean)
+  fun setVipCalloutAlreadySeen(wallet: String, isSeen: Boolean)
 
 }

--- a/gamification/src/main/java/com/appcoins/wallet/gamification/repository/UserStatsLocalData.kt
+++ b/gamification/src/main/java/com/appcoins/wallet/gamification/repository/UserStatsLocalData.kt
@@ -45,7 +45,7 @@ interface UserStatsLocalData {
 
   fun getSeenWalletOrigin(wallet: String): String
 
-  fun isVipCalloutAlreadySeen(): Boolean
+  fun isVipCalloutAlreadySeen(wallet: String): Boolean
 
-  fun setVipCalloutAlreadySeen(isSeen: Boolean)
+  fun setVipCalloutAlreadySeen(wallet: String, isSeen: Boolean)
 }


### PR DESCRIPTION
**What does this PR do?**

   Fixes the VIP callouts when rotating the screen or switching wallet.
   Added the ability to show the VIP callout by wallet, if it matches the criteria.
   Switching to a wallet that matches the criteria, would show the VIP callout right away

**Database changed?**

   No

**Where should the reviewer start?**

- IsNewVipUseCase.kt
- NavBarViewModel.kt
- BdsPromotionsRepository.kt

**How should this be manually tested?**

- Switch to a wallet that is a vip and has not seen the callout yet
- Dont navigate to promotions just yet (to avoid removing the callout)
- Switch to a non vip wallet and check if the callout is not present
- Switch back to the VIP wallet and check the callout
- Navigate to promotions or click the callout
- Check if the callout appears again when rotating the screen or locking the phone

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3345

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
