### PR TITLE
3DS2 Activity on payment task

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,7 +166,7 @@
     <activity
         android:name="com.asfoundation.wallet.ui.iab.IabActivity"
         android:exported="true"
-        android:launchMode="singleInstance"
+        android:launchMode="singleTask"
         android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
@@ -268,22 +268,19 @@
         android:name="com.asfoundation.wallet.eskills.withdraw.WithdrawActivity"
         android:label="@string/e_skills_withdraw_title" />
 
-<!--    Copy pasted from the Adyen lib to resolve the navigation issue in the payments    -->
-<!--    "taskAffinity" and "excludeFromRecents" added to overcome the issue    -->
+    <!-- Overrides adyen manifest to force the 3ds2 activity to run on the same task as the payment-->
+    <!-- The standard adyen behavior would open the 3ds2 activity in the "main" wallet task, -->
     <activity
         android:name="com.adyen.threeds2.internal.ui.activity.ChallengeActivity"
         android:exported="true"
-        android:taskAffinity=".challenge"
-        android:excludeFromRecents="true"
-        android:launchMode="singleTask"
+        android:launchMode="singleTop"
         android:theme="@style/ThreeDS2Theme.Internal"
-        android:windowSoftInputMode="stateHidden" >
+        android:windowSoftInputMode="stateHidden"
+        tools:replace="launchMode">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
-
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-
         <data
             android:host="${applicationId}"
             android:scheme="adyen3ds2" />


### PR DESCRIPTION
**What does this PR do?**
OOB 3ds flows (with authorization in the banking app) were not be able to be completed, due to the Adyen sdk not allowing the user to get back to the Adyen 3ds screen after authorizing the payment on the banking app.
Now the 3ds screen is kept open until the user goes back to the game.

**Where should the reviewer start?**
AndroidManifest

**How should this be manually tested?**
To replicate the issue, do a payment with a CC with 3ds OOB.

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
