### PR TITLE
[bugfix/APPC-3378] Backup trigger duplicated fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/triggers/BackupTriggerDialogFragment.kt
@@ -33,6 +33,7 @@ class BackupTriggerDialogFragment : BottomSheetDialogFragment(),
   companion object {
     const val WALLET_ADDRESS_KEY = "wallet_address"
     const val TRIGGER_SOURCE = "trigger_source"
+    var showing = false
 
     @JvmStatic
     fun newInstance(
@@ -53,6 +54,7 @@ class BackupTriggerDialogFragment : BottomSheetDialogFragment(),
     inflater: LayoutInflater, container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
+    if (showing) dismiss() else showing = true
     return inflater.inflate(R.layout.backup_trigger_dialog_fragment, container, false)
   }
 


### PR DESCRIPTION
**What does this PR do?**

   Fixes the backup bottom sheet trigger in home showing duplicated on top of each other.
   Its an issue with dialogs like this, similar to the same problem already fixed with the Almost VIP new dialog

**Database changed?**

   No

**How should this be manually tested?**

- Create a new wallet
- make an IAP payment
- Open the wallet again to trigger the bottom sheet
- the bottomshet should not show duplicated

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-3378

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
