### PR TITLE
[APPC-3387] Deactivate gas_price request on payments

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/service/GasService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/service/GasService.kt
@@ -1,6 +1,5 @@
 package com.asfoundation.wallet.service
 
-import com.asf.wallet.BuildConfig
 import com.google.gson.annotations.SerializedName
 import io.reactivex.Single
 import retrofit2.http.GET

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -225,6 +225,7 @@ public class InAppPurchaseInteractor {
   //public Single<Boolean> hasAppcoinsFunds(TransactionBuilder transaction) {
   //  return asfInAppPurchaseInteractor.isAppcoinsPaymentReady(transaction);
   //}
+  //
 
   public Single<InAppPurchaseService.BalanceState> getBalanceState(TransactionBuilder transaction) {
     return asfInAppPurchaseInteractor.getAppcoinsBalanceState(transaction);

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -208,15 +208,23 @@ public class InAppPurchaseInteractor {
         .onErrorReturn(throwable -> false);
   }
 
+  // uncomment to reactivate gas_price on payment flow:
+  //private Single<List<Gateway.Name>> getFilteredGateways(TransactionBuilder transactionBuilder) {
+  //  return Single.zip(getRewardsBalance(), hasAppcoinsFunds(transactionBuilder),
+  //      (creditsBalance, hasAppcoinsFunds) -> getNewPaymentGateways(creditsBalance,
+  //          hasAppcoinsFunds, transactionBuilder.amount()));
+  //}
+
   private Single<List<Gateway.Name>> getFilteredGateways(TransactionBuilder transactionBuilder) {
-    return Single.zip(getRewardsBalance(), hasAppcoinsFunds(transactionBuilder),
-        (creditsBalance, hasAppcoinsFunds) -> getNewPaymentGateways(creditsBalance,
-            hasAppcoinsFunds, transactionBuilder.amount()));
+    return getRewardsBalance()
+        .map( creditsBalance ->
+            getNewPaymentGateways(creditsBalance, false, transactionBuilder.amount())
+        );
   }
 
-  public Single<Boolean> hasAppcoinsFunds(TransactionBuilder transaction) {
-    return asfInAppPurchaseInteractor.isAppcoinsPaymentReady(transaction);
-  }
+  //public Single<Boolean> hasAppcoinsFunds(TransactionBuilder transaction) {
+  //  return asfInAppPurchaseInteractor.isAppcoinsPaymentReady(transaction);
+  //}
 
   public Single<InAppPurchaseService.BalanceState> getBalanceState(TransactionBuilder transaction) {
     return asfInAppPurchaseInteractor.getAppcoinsBalanceState(transaction);


### PR DESCRIPTION
**What does this PR do?**
Deactivates unnecessary transaction/gas_price request from the payment flow. The endpoint is still used on "send" and NFTs.

**Database changed?**
No

**How should this be manually tested?**
Basic tests on payment flow.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3387

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
