### PR TITLE
[APPC-3404] Retry option on payment errors

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
@@ -733,11 +733,8 @@ class AdyenPaymentPresenter(
     disposables.add(view.adyenErrorBackClicks()
       .observeOn(viewScheduler)
       .doOnNext {
-        if (isPreSelected) {
-          view.close(adyenPaymentInteractor.mapCancellation())
-        } else {
-          view.showMoreMethods()
-        }
+        adyenPaymentInteractor.removePreSelectedPaymentMethod()
+        view.showMoreMethods()
       }
       .subscribe({}, {
         logger.log(TAG, it)
@@ -749,7 +746,9 @@ class AdyenPaymentPresenter(
   private fun handleAdyenErrorCancel() {
     disposables.add(view.adyenErrorCancelClicks()
       .observeOn(viewScheduler)
-      .doOnNext { view.close(adyenPaymentInteractor.mapCancellation()) }
+      .doOnNext {
+        view.close(adyenPaymentInteractor.mapCancellation())
+      }
       .subscribe({}, {
         logger.log(TAG, it)
         view.showGenericError()

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
@@ -120,7 +120,7 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
   override fun close() = iabView.close(billingMessagesMapper.mapCancellation())
 
   override fun showError(message: Int?) {
-    error_dismiss.setText(getString(R.string.ok))
+    error_dismiss.setText(getString(R.string.back_button))
     error_message.text = getString(message ?: R.string.activity_iab_error_message)
     generic_error_layout.visibility = View.VISIBLE
     hideLoading()
@@ -139,6 +139,11 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
   }
 
   override fun errorClose() = iabView.close(billingMessagesMapper.genericError())
+
+  override fun showPaymentMethods() {
+    iabView.unlockRotation()
+    iabView.showPaymentMethodsView()
+  }
 
   override fun finish(purchase: Purchase, orderReference: String?) {
     presenter.sendPaymentEvent()

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
@@ -46,7 +46,9 @@ class AppcoinsRewardsBuyPresenter(
 
   private fun handleOkErrorClick() {
     disposables.add(view.getOkErrorClick()
-      .doOnNext { view.errorClose() }
+      .doOnNext {
+        view.showPaymentMethods()
+      }
       .subscribe({}, {
         logger.log(TAG, "Ok error click", it)
         view.errorClose()

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.kt
@@ -27,6 +27,8 @@ interface AppcoinsRewardsBuyView {
 
   fun errorClose()
 
+  fun showPaymentMethods()
+
   fun finish(purchase: Purchase, orderReference: String?)
 
   fun showTransactionCompleted()


### PR DESCRIPTION
**What does this PR do?**
Allows the user to retry a payment with a different payment method if there was an error, instead of closing the payment flow.

**Database changed?**
No

**How should this be manually tested?**
On the credit card screen, turn-off the internet and try to proceed. Then click to go back.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3404

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
