### PR TITLE
[APPC-3471] Fix GetOwnerWallet cache specific to each package

### DIFF
--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
@@ -241,12 +241,16 @@ class RemoteRepository(
     brokerBdsApi.getAppcoinsTransaction(uid, address, signedContent)
 
   var ownerWalletCached: GetWalletResponse? = null
+  var packageNameCached: String? = null
   fun getWallet(packageName: String, fromCache: Boolean = true): Single<GetWalletResponse> {
-    return if (fromCache && ownerWalletCached != null)
+    return if (fromCache && ownerWalletCached != null && packageNameCached == packageName)
       Single.just(ownerWalletCached)
     else
       bdsApiSecondary.getWallet(packageName)
-        .doOnSuccess { ownerWalletCached = it }
+        .doOnSuccess {
+          ownerWalletCached = it
+          packageNameCached = packageName
+        }
   }
 
   fun transferCredits(


### PR DESCRIPTION
**What does this PR do?**
If a user did 2 purchases in different games in quick succession, the wallet of the first could still be cached.

**Database changed?**
No

**How should this be manually tested?**
Two purchases in different games without closing the wallet.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3471

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
