### PR TITLE
[BugFix/APPC-3425] Handle PayPal cancel correctly

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentViewModel.kt
@@ -225,17 +225,20 @@ class OnboardingAdyenPaymentViewModel @Inject constructor(
       WebViewActivity.SUCCESS -> {
         if (result.data?.scheme?.contains("adyencheckout") == true) {
           events.sendPaypalUrlEvent(args.transactionBuilder, result.data!!)
-          if (events.getQueryParameter(result.data!!, "resultCode") == "cancelled") {
-            events.sendPayPalConfirmationEvent(args.transactionBuilder, "cancel")
-          } else {
-            events.sendPayPalConfirmationEvent(args.transactionBuilder, "buy")
-          }
+          events.sendPayPalConfirmationEvent(args.transactionBuilder, "buy")
         }
         sendSideEffect {
           result.data!!.data?.let { uri ->
             OnboardingAdyenPaymentSideEffect.HandleWebViewResult(uri)
           }
         }
+      }
+      WebViewActivity.USER_CANCEL -> {
+        if (result.data?.scheme?.contains("adyencheckout") == true) {
+          events.sendPaypalUrlEvent(args.transactionBuilder, result.data!!)
+          events.sendPayPalConfirmationEvent(args.transactionBuilder, "cancel")
+        }
+        sendSideEffect { OnboardingAdyenPaymentSideEffect.NavigateBackToPaymentMethods }
       }
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityPresenter.kt
@@ -49,13 +49,19 @@ class TopUpActivityPresenter(
 
   fun processActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     if (requestCode == TopUpActivity.WEB_VIEW_REQUEST_CODE) {
-      if (resultCode == WebViewActivity.SUCCESS && data != null) {
-        data.data?.let { view.acceptResult(it) } ?: view.cancelPayment()
-      } else if (resultCode == WebViewActivity.FAIL) {
-        if (data?.dataString?.contains(BillingWebViewFragment.OPEN_SUPPORT) == true) {
-          logger.log(TAG, Exception("ActivityResult ${data.dataString}"))
-          cancelPaymentAndShowSupport()
-        } else {
+      when (resultCode) {
+        WebViewActivity.FAIL -> {
+          if (data?.dataString?.contains(BillingWebViewFragment.OPEN_SUPPORT) == true) {
+            logger.log(TAG, Exception("ActivityResult ${data.dataString}"))
+            cancelPaymentAndShowSupport()
+          } else {
+            view.cancelPayment()
+          }
+        }
+        WebViewActivity.SUCCESS -> {
+          data?.data?.let { view.acceptResult(it) } ?: view.cancelPayment()
+        }
+        WebViewActivity.USER_CANCEL -> {
           view.cancelPayment()
         }
       }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -210,31 +210,38 @@ class IabPresenter(
   }
 
   private fun handleWebViewResult(resultCode: Int, data: Intent?) {
-    if (resultCode == WebViewActivity.FAIL) {
-      if (data?.dataString?.contains("codapayments") != true) {
-        if (data?.dataString?.contains(
-            BillingWebViewFragment.CARRIER_BILLING_ONE_BIP_SCHEMA
-          ) == true
-        ) {
-          sendCarrierBillingConfirmationEvent("cancel")
-        } else {
+    when (resultCode) {
+      WebViewActivity.FAIL -> {
+        if (data?.dataString?.contains("codapayments") != true) {
+          if (data?.dataString?.contains(
+              BillingWebViewFragment.CARRIER_BILLING_ONE_BIP_SCHEMA
+            ) == true
+          ) {
+            sendCarrierBillingConfirmationEvent("cancel")
+          } else {
+            sendPayPalConfirmationEvent("cancel")
+          }
+        }
+        if (data?.dataString?.contains(BillingWebViewFragment.OPEN_SUPPORT) == true) {
+          logger.log(TAG, Exception("WebViewResult ${data.dataString}"))
+          iabInteract.showSupport()
+        }
+        view.showPaymentMethodsView()
+      }
+      WebViewActivity.SUCCESS -> {
+        if (data?.scheme?.contains("adyencheckout") == true) {
+          sendPaypalUrlEvent(data)
+          sendPayPalConfirmationEvent("buy")
+        }
+        view.successWebViewResult(data!!.data)
+      }
+      WebViewActivity.USER_CANCEL -> {
+        if (data?.scheme?.contains("adyencheckout") == true) {
+          sendPaypalUrlEvent(data)
           sendPayPalConfirmationEvent("cancel")
         }
+        view.showPaymentMethodsView()
       }
-      if (data?.dataString?.contains(BillingWebViewFragment.OPEN_SUPPORT) == true) {
-        logger.log(TAG, Exception("WebViewResult ${data.dataString}"))
-        iabInteract.showSupport()
-      }
-      view.showPaymentMethodsView()
-    } else if (resultCode == WebViewActivity.SUCCESS) {
-      if (data?.scheme?.contains("adyencheckout") == true) {
-        sendPaypalUrlEvent(data)
-        if (getQueryParameter(data, "resultCode") == "cancelled")
-          sendPayPalConfirmationEvent("cancel")
-        else
-          sendPayPalConfirmationEvent("buy")
-      }
-      view.successWebViewResult(data!!.data)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/WebViewActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/WebViewActivity.kt
@@ -76,7 +76,9 @@ class WebViewActivity() : AppCompatActivity() {
 
     const val SUCCESS = 1
     const val FAIL = 0
+    const val USER_CANCEL = 2
     private const val URL = "url"
+    const val USER_CANCEL_THROWABLE = "user_cancel"
 
     fun newIntent(activity: Activity?, url: String?): Intent {
       return Intent(activity, WebViewActivity::class.java).apply {

--- a/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalFragment.kt
@@ -48,6 +48,8 @@ class VerificationPaypalFragment : BasePageViewFragment(),
       viewModel.successPayment()
     } else if (resultCode == WebViewActivity.FAIL) {
       viewModel.failPayment()
+    } else if (resultCode == WebViewActivity.USER_CANCEL) {
+      viewModel.cancelPayment()
     }
   }
 
@@ -95,6 +97,8 @@ class VerificationPaypalFragment : BasePageViewFragment(),
   private fun setError(error: Error) {
     if (error is Error.ApiError.NetworkError)
       showNetworkError()
+    else if (error.throwable.message.equals(WebViewActivity.USER_CANCEL_THROWABLE))
+      handleUserCancelError()
     else
       showGenericError()
   }
@@ -142,6 +146,11 @@ class VerificationPaypalFragment : BasePageViewFragment(),
       views.genericError.tryAgain.visibility = View.GONE
     }
     views.genericError.errorMessage.text = getString(R.string.unknown_error)
+  }
+
+  private fun handleUserCancelError() {
+    hideAll()
+    navigator.navigateBack()
   }
 
   private fun hideAll() {

--- a/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalViewModel.kt
@@ -2,6 +2,7 @@ package com.asfoundation.wallet.verification.ui.paypal
 
 import com.appcoins.wallet.billing.adyen.AdyenPaymentRepository
 import com.asfoundation.wallet.base.*
+import com.asfoundation.wallet.ui.iab.WebViewActivity
 import com.asfoundation.wallet.verification.ui.credit_card.WalletVerificationInteractor
 import com.asfoundation.wallet.verification.ui.credit_card.intro.VerificationIntroModel
 import com.asfoundation.wallet.verification.ui.credit_card.network.VerificationStatus
@@ -71,6 +72,11 @@ class VerificationPaypalViewModel(
   fun failPayment() {
     setState { copy(verificationSubmitAsync = Async.Fail(Error.UnknownError(Throwable("")))) }
   }
+
+  fun cancelPayment() {
+      setState { copy(verificationSubmitAsync = Async.Fail(Error.UnknownError(Throwable(WebViewActivity.USER_CANCEL_THROWABLE)))) }
+  }
+
 
   fun tryAgain() {
     setState { copy(verificationSubmitAsync = Async.Uninitialized) }


### PR DESCRIPTION
**What does this PR do?**

Handle PayPal cancel action in webView Login into verify my Wallet

**Database changed?**

    No

**How should this be manually tested?**

Have a wallet that is not verified, when trying to verify with PayPal, a button will appear that will have the option to cancel and return to Wallet, by clicking on this button you will be redirected to the wallet

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3425](https://aptoide.atlassian.net/browse/APPC-3425?atlOrigin=eyJpIjoiMTJjZDZlMTQzOWQ1NDc0MWE4ZGQzMTQ4MjU5ZGUyNjAiLCJwIjoiaiJ9)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
