### PR TITLE
[APPC-3617] Target Android 13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
       tools:ignore="ProtectedPermissions" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/com/asfoundation/wallet/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/ui/HomeFragment.kt
@@ -2,12 +2,14 @@ package com.asfoundation.wallet.home.ui
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupWindow
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -51,6 +53,10 @@ class HomeFragment : BasePageViewFragment(),
   private lateinit var tooltip: View
   private lateinit var popup: PopupWindow
 
+  private val pushNotificationPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+//    viewModel.inputs.onTurnOnNotificationsClicked(granted)
+  }
+
   override fun onCreateView(
     inflater: LayoutInflater, container: ViewGroup?,
     savedInstanceState: Bundle?
@@ -72,6 +78,7 @@ class HomeFragment : BasePageViewFragment(),
     views.toolbar.actionButtonSupport.setOnClickListener { viewModel.showSupportScreen(false) }
     views.toolbar.actionButtonSettings.setOnClickListener { viewModel.onSettingsClick() }
     viewModel.collectStateAndEvents(lifecycle, viewLifecycleOwner.lifecycleScope)
+    askNotificationsPermission()
   }
 
   override fun onPause() {
@@ -246,5 +253,14 @@ class HomeFragment : BasePageViewFragment(),
 
   private fun onTransactionClick(transaction: Transaction) {
     viewModel.onTransactionDetailsClick(transaction)
+  }
+
+  private fun askNotificationsPermission() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      // Android OS manages when to ask for permission. After android 11, the default behavior is
+      // to only prompt for permission if needed, and if the user didn't deny it twice before. If
+      // the user just dismissed it without denying, then it'll prompt again next time.
+      pushNotificationPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+    }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/ui/HomeFragment.kt
@@ -53,9 +53,8 @@ class HomeFragment : BasePageViewFragment(),
   private lateinit var tooltip: View
   private lateinit var popup: PopupWindow
 
-  private val pushNotificationPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-//    viewModel.inputs.onTurnOnNotificationsClicked(granted)
-  }
+  private val pushNotificationPermissionLauncher =
+    registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
   override fun onCreateView(
     inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -20,10 +20,9 @@ import androidx.lifecycle.lifecycleScope
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.appcoins.wallet.core.utils.properties.PRIVACY_POLICY_URL
 import com.appcoins.wallet.core.utils.properties.TERMS_CONDITIONS_URL
-import com.asf.wallet.BuildConfig
+import com.appcoins.wallet.ui.arch.SingleStateFragment
 import com.asf.wallet.R
 import com.asf.wallet.databinding.FragmentOnboardingBinding
-import com.appcoins.wallet.ui.arch.SingleStateFragment
 import com.asfoundation.wallet.my_wallets.create_wallet.CreateWalletDialogFragment
 import com.asfoundation.wallet.viewmodel.BasePageViewFragment
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -68,7 +69,13 @@ class RecoverEntryFragment : BasePageViewFragment(),
       navigator.navigateBack(fromActivity = !isOnboardingLayout)
     }
     views.recoverWalletOptions.recoverFromFileButton.setOnClickListener {
-      requestPermissionsLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+      // For Android 33 and beyond, the READ_EXTERNAL_STORAGE permission does not work. Though it's
+      // still needed for backward compatibility.
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        requestPermissionsLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+      } else {
+        navigator.launchFileIntent(storageIntentLauncher, viewModel.filePath())
+      }
     }
     views.recoverWalletButton.setOnClickListener {
       viewModel.handleRecoverClick(


### PR DESCRIPTION
**What does this PR do?**
Lineups necessary for Android 13:
 - notifications permission and prompt,
 - storage access logic to not depend on previous prompt

**Database changed?**
No

**How should this be manually tested?**
Check Recover Wallet.
Check notifications permission when opening the wallet.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3617

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
