### PR TITLE
Rotation lock after the first payment flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/payment_result/OnboardingPaymentResultNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/payment_result/OnboardingPaymentResultNavigator.kt
@@ -1,6 +1,7 @@
 package com.asfoundation.wallet.onboarding_new_payment.payment_result
 
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -34,10 +35,12 @@ class OnboardingPaymentResultNavigator @Inject constructor(
   }
 
   fun navigateToHome() {
+    fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
     fragment.setFragmentResult(ONBOARDING_PAYMENT_CONCLUSION, bundleOf("fragmentEnded" to "result"))
   }
 
   fun navigateBackToPaymentMethods() {
+    fragment.requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
     fragment.findNavController()
       .popBackStack(R.id.onboarding_payment_methods_fragment, inclusive = false)
   }


### PR DESCRIPTION
**What does this PR do?**

   fixes screen rotation lock when finishing the first payment flow

**Database changed?**

   No

**How should this be manually tested?**

  - finish a payment in the new flow
  - go to the home (explore wallet) and try to rotate the screen

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
