### PR TITLE
[APPC-3717] Bug in First Payment flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/payment_methods/OnboardingPaymentMethodsViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/payment_methods/OnboardingPaymentMethodsViewModel.kt
@@ -48,7 +48,18 @@ class OnboardingPaymentMethodsViewModel @Inject constructor(
   private fun handlePaymentMethods() {
     cachedTransactionRepository.getCachedTransaction()
       .flatMap { cachedTransaction ->
-        getFirstPaymentMethodsUseCase(cachedTransaction)
+        var diffCachedTransaction = cachedTransaction
+         if (cachedTransaction.value <= 0.0) {
+           diffCachedTransaction = cachedTransaction.copy(
+             value = args.amount.toDouble()
+           )
+         }
+        if (cachedTransaction.currency.isNullOrEmpty()) {
+          diffCachedTransaction = diffCachedTransaction.copy(
+            currency = args.currency
+          )
+        }
+        getFirstPaymentMethodsUseCase(diffCachedTransaction)
           // to only use getFirstPaymentMethodsUseCase and remove the doOnSuccess after all methods are ready
           .doOnSuccess { availablePaymentMethods ->
             setState {


### PR DESCRIPTION

**What does this PR do?**

Fix a bug in some games when cached transaction has a value with 0 and currency to null, showing was error view to user.

**Database changed?**

    No

**Where should the reviewer start?**

- [ ] OnboadingPaymentMethodsViewModel.kt

**How should this be manually tested?**

  set some value 0 and currency to null into a product to in DEV to get a response in this api - /transaction/inapp/cached_values
  and with new apk not show error view .

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3717](https://aptoide.atlassian.net/browse/APPC-3717)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
