### PR TITLE
[APPC-3812] Fix AdyenPaymentFragment error strings and support button

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
@@ -157,6 +157,7 @@ class AdyenPaymentFragment : BasePageViewFragment(), AdyenPaymentView {
   // support_error_layout.xml
   private val error_message: TextView
     get() = bindingCreditCardLayout?.fragmentAdyenError?.errorMessage
+      ?: bindingCreditCardPreSelected?.fragmentAdyenErrorPreSelected?.errorMessage
       ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.errorMessage
       ?: bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.errorMessage!!
   private val error_verify_wallet_button: WalletButtonView
@@ -166,11 +167,15 @@ class AdyenPaymentFragment : BasePageViewFragment(), AdyenPaymentView {
     get() = bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.errorVerifyCardButton
       ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.errorVerifyCardButton!!
   private val layout_support_logo: ImageView
-    get() = bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.layoutSupportLogo
-      ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.layoutSupportLogo!!
+    get() = bindingCreditCardLayout?.fragmentAdyenError?.layoutSupportLogo
+      ?: bindingCreditCardPreSelected?.fragmentAdyenErrorPreSelected?.layoutSupportLogo
+      ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.layoutSupportLogo
+      ?: bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.layoutSupportLogo!!
   private val layout_support_icn: ImageView
-    get() = bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.layoutSupportIcn
-      ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.layoutSupportIcn!!
+    get() = bindingCreditCardLayout?.fragmentAdyenError?.layoutSupportIcn
+      ?: bindingCreditCardPreSelected?.fragmentAdyenErrorPreSelected?.layoutSupportIcn
+      ?: bindingCreditCardLayout?.fragmentIabError?.genericErrorLayout?.layoutSupportIcn
+      ?: bindingCreditCardPreSelected?.fragmentIabErrorPreSelected?.genericErrorLayout?.layoutSupportIcn!!
 
   // view_purchase_bonus.xml
   private val bonus_value: TextView

--- a/legacy/bdsbilling/src/test/java/com/appcoins/wallet/bdsbilling/BillingPaymentProofSubmissionTest.kt
+++ b/legacy/bdsbilling/src/test/java/com/appcoins/wallet/bdsbilling/BillingPaymentProofSubmissionTest.kt
@@ -212,7 +212,6 @@ package com.appcoins.wallet.bdsbilling
 //    ).subscribe(purchaseDisposable)
 //    scheduler.triggerActions()
 //
-//
 //    authorizationDisposable.assertNoErrors().assertComplete()
 //    purchaseDisposable.assertNoErrors().assertComplete()
 //    verify(brokerBdsApi, times(1)).createTransaction(


### PR DESCRIPTION
**What does this PR do?**
1. Fix the support button not working in AdyenPaymentFragment.
2. Fix error strings not displaying in the pre-selected layout of the same class.

**Database changed?**
No

**How should this be manually tested?**
1. Force any error, for example a wrong date on a valid card.
2. Make a purchase with a credit card, then start another one but this time change the card so that the payment errors out.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3812

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
