### PR TITLE
[APPC-3849] Fix Onboarding create wallet not navigating

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -48,6 +48,10 @@ class OnboardingFragment : BasePageViewFragment(),
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     handleBackPress()
+  }
+
+  override fun onResume() {
+    super.onResume()
     handleWalletCreationFragmentResult()
   }
 


### PR DESCRIPTION
**What does this PR do?**
In the onboarding flow, when navigating from the Recover back to the onboarding fragment, the FragmentResultListener was lost.

**Database changed?**
No

**How should this be manually tested?**
Onboarding fragment -> already have a wallet -> back -> create wallet

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3849

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
