### PR TITLE
Adds wallet creation flow to eskills activity calls

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
@@ -54,13 +54,7 @@ class OneStepPaymentReceiver : BaseActivity() {
     super.onCreate(savedInstanceState)
 
     if (savedInstanceState == null) analytics.startTimingForOspTotalEvent()
-    if (isEskillsUri(intent.dataString!!)) {
-      val skillsActivityIntent = Intent(this, SkillsActivity::class.java)
-      skillsActivityIntent.putExtra(ESKILLS_URI_KEY, intent.dataString)
-      @Suppress("DEPRECATION")
-      startActivityForResult(skillsActivityIntent, REQUEST_CODE)
-    } else {
-      setContentView(R.layout.activity_iab_wallet_creation)
+    setContentView(R.layout.activity_iab_wallet_creation)
       walletCreationCard = findViewById(R.id.create_wallet_card)
       walletCreationAnimation = findViewById(R.id.create_wallet_animation)
       walletCreationText = findViewById(R.id.create_wallet_text)
@@ -73,7 +67,13 @@ class OneStepPaymentReceiver : BaseActivity() {
               .flatMap { transaction: TransactionBuilder ->
                 inAppPurchaseInteractor.isWalletFromBds(transaction.domain, transaction.toAddress())
                   .doOnSuccess { isBds: Boolean ->
-                    startOneStepTransfer(transaction, isBds)
+                    if (isEskillsUri(intent.dataString!!)) {
+                      val skillsActivityIntent = Intent(this, SkillsActivity::class.java)
+                      skillsActivityIntent.putExtra(ESKILLS_URI_KEY, intent.dataString)
+                      @Suppress("DEPRECATION")
+                      startActivityForResult(skillsActivityIntent, REQUEST_CODE)
+                    }
+                    else{startOneStepTransfer(transaction, isBds)}
                   }
               }
               .toObservable()
@@ -84,7 +84,6 @@ class OneStepPaymentReceiver : BaseActivity() {
           })
       }
     }
-  }
 
   @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
**What does this PR do?**

Eskills flow was crashing when user hadn't launched the wallet prior to a game. 
Skills activity calls are now only called after checking if wallet is created.
**Database changed?**

   Yes | No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Foo.kt

**How should this be manually tested?**

- Uninstall Wallet
- Install Wallet without opening it ( Make sure wallet creation flow doesn't start)
- Open eSkills game and try to make a purchase
- You should see the wallet creation flow, prior to the payment fragment.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ESKL-365](https://aptoide.atlassian.net/browse/ESKL-365)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[ESKL-365]: https://aptoide.atlassian.net/browse/ESKL-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ