### PR TITLE
[APCC-3930][Fix] Change navigation from recover to NavBar instead to home_graph

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/entry/RecoverEntryNavigator.kt
@@ -11,9 +11,7 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.appcoins.wallet.core.arch.data.Navigator
 import com.appcoins.wallet.core.arch.data.navigate
-import com.appcoins.wallet.core.network.backend.model.WalletHistory
 import com.asfoundation.wallet.entity.WalletKeyStore
-import com.asfoundation.wallet.recover.RecoverActivity
 import com.asfoundation.wallet.recover.success.RecoveryWalletSuccessBottomSheetFragment
 import javax.inject.Inject
 
@@ -66,11 +64,11 @@ class RecoverEntryNavigator @Inject constructor(val fragment: Fragment) :
     bottomSheet.show(fragment.parentFragmentManager, "RecoveryWalletSuccess")
   }
 
-  fun navigateToMainHomeGraph(navController: NavController) {
+  fun navigateToNavBarGraph(navController: NavController) {
     with(navController) {
       navigate(
-       this,
-        RecoverEntryFragmentDirections.actionNavigateToHomeGraph()
+        this,
+        RecoverEntryFragmentDirections.actionNavigateToNavBarFragment()
       )
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
@@ -53,7 +53,7 @@ class RecoveryWalletSuccessBottomSheetFragment : BottomSheetDialogFragment(),
 
     views.recoveryWalletBottomButton.setOnClickListener {
       if (requireArguments().getSerializable(IS_FROM_ONBOARDING) as Boolean) {
-        navigator.navigateToMainHomeGraph(navController())
+        navigator.navigateToNavBarGraph(navController())
       } else {
         navigator.navigateBack()
       }

--- a/app/src/main/res/navigation/recover_wallet_graph.xml
+++ b/app/src/main/res/navigation/recover_wallet_graph.xml
@@ -5,8 +5,6 @@
     android:id="@+id/recover_wallet_graph"
     app:startDestination="@id/recover_entry_fragment">
 
-  <include app:graph="@navigation/home_graph" />
-
   <fragment
       android:id="@+id/recover_entry_fragment"
       android:name="com.asfoundation.wallet.recover.entry.RecoverEntryFragment"
@@ -25,11 +23,11 @@
         app:destination="@id/create_wallet_dialog_fragment" />
 
     <action
-        android:id="@+id/action_navigate_to_home_graph"
-        app:destination="@id/home_graph"
+        android:id="@+id/action_navigate_to_nav_bar_fragment"
+        app:destination="@id/nav_bar_fragment"
         app:launchSingleTop="true"
         app:popUpTo="@id/recover_entry_fragment"
-        app:popUpToInclusive="true"/>
+        app:popUpToInclusive="true" />
   </fragment>
 
   <fragment
@@ -59,13 +57,6 @@
     <action
         android:id="@+id/action_navigate_to_nav_bar_fragment"
         app:destination="@id/nav_bar_fragment"
-        app:popUpTo="@id/recover_entry_fragment"
-        app:popUpToInclusive="true"/>
-
-    <action
-        android:id="@+id/action_navigate_to_home_graph"
-        app:destination="@id/home_graph"
-        app:launchSingleTop="true"
         app:popUpTo="@id/recover_entry_fragment"
         app:popUpToInclusive="true"/>
   </fragment>


### PR DESCRIPTION
**What does this PR do?**

  Fix bug where bottom navigation is not appearing when comes from Recover

**Database changed?**

  No

**How should this be manually tested?**

  try to recover a wallet from onboarding, bottom navigation should appears at home

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3930](https://aptoide.atlassian.net/browse/APPC-3930)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-3930]: https://aptoide.atlassian.net/browse/APPC-3930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ