### PR TITLE
[APPC-3939] Fix overlapping button on pre-selected payment method screen

### DIFF
--- a/app/src/main/res/layout/payment_methods_layout.xml
+++ b/app/src/main/res/layout/payment_methods_layout.xml
@@ -185,7 +185,7 @@
               android:layout_height="@dimen/small_button_height"
               android:layout_gravity="center_vertical"
               android:layout_marginTop="6dp"
-              android:layout_marginBottom="42dp"
+              android:layout_marginBottom="52dp"
               app:buttonText="@string/purchase_more_payment_methods_lower_case_button"
               app:buttonType="text"
               app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/payment_methods_layout.xml
+++ b/app/src/main/res/layout/payment_methods_layout.xml
@@ -22,11 +22,11 @@
         android:layout_width="128dp"
         android:layout_height="128dp"
         android:layout_centerInParent="true"
+        android:visibility="gone"
         app:lottie_autoPlay="true"
         app:lottie_enableMergePathsForKitKatAndAbove="true"
         app:lottie_loop="true"
         app:lottie_rawRes="@raw/loading_wallet"
-        android:visibility="gone"
         />
 
     <LinearLayout
@@ -188,11 +188,11 @@
               android:layout_marginBottom="52dp"
               app:buttonText="@string/purchase_more_payment_methods_lower_case_button"
               app:buttonType="text"
+              app:layout_constraintBottom_toBottomOf="parent"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintHorizontal_bias="1.0"
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toBottomOf="@+id/layout_pre_selected"
-              app:layout_constraintBottom_toBottomOf="parent"
               />
 
           <androidx.constraintlayout.widget.Group
@@ -220,8 +220,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:background="@color/styleguide_payments_background"
-            app:layout_constraintTop_toTopOf="@id/bonus_layout"
             app:layout_constraintBottom_toTopOf="@id/bottom_separator_buttons"
+            app:layout_constraintTop_toTopOf="@id/bonus_layout"
             />
 
         <include


### PR DESCRIPTION
**What does this PR do?**
When a payment method was preselected and the bonus was showing, the "other payment methods" button was hidden behind the bonus

**Database changed?**
No

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-3939

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] Database migration (if applicable)?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass
