### PR TITLE
[APPC-3982] Show BalanceBottomSheet on Home balance click

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeNavigator.kt
@@ -8,9 +8,11 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import com.appcoins.wallet.core.arch.data.Navigator
+import com.appcoins.wallet.feature.walletInfo.data.balance.WalletBalance
 import com.asf.wallet.R
 import com.asfoundation.wallet.backup.BackupWalletEntryFragment.Companion.WALLET_ADDRESS_KEY
 import com.asfoundation.wallet.backup.BackupWalletEntryFragment.Companion.WALLET_NAME
+import com.asfoundation.wallet.manage_wallets.bottom_sheet.ManageWalletBalanceBottomSheetFragment
 import com.asfoundation.wallet.rating.RatingActivity
 import com.asfoundation.wallet.recover.RecoverActivity
 import com.asfoundation.wallet.topup.TopUpActivity
@@ -69,8 +71,15 @@ constructor(
     fragment.requireContext().startActivity(intent)
   }
 
-  fun navigateToCurrencySelector(mainNavController: NavController) {
-    mainNavController.navigate(R.id.action_navigate_to_change_fiat_currency)
+  fun navigateToBalanceBottomSheet(walletBalance: WalletBalance) {
+    val bottomSheet = ManageWalletBalanceBottomSheetFragment.newInstance()
+    val bundle = Bundle()
+    bundle.putSerializable(
+      ManageWalletBalanceBottomSheetFragment.WALLET_BALANCE_MODEL,
+      walletBalance
+    )
+    bottomSheet.arguments = bundle
+    bottomSheet.show(fragment.parentFragmentManager, "HomeBalanceWallet")
   }
 
   fun navigateToManageBottomSheet() {

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
@@ -40,9 +40,7 @@ import com.appcoins.wallet.ui.widgets.component.ButtonWithIcon
 
 @Composable
 fun BalanceCard(
-  balance: String,
-  currencyCode: String,
-  onClickCurrencies: () -> Unit,
+  balanceContent: @Composable () -> Unit,
   onClickTransfer: () -> Unit,
   onClickTopUp: () -> Unit,
   onClickBackup: () -> Unit,
@@ -53,9 +51,7 @@ fun BalanceCard(
   BoxWithConstraints {
     if (expanded()) {
       BalanceCardExpanded(
-        balance = balance,
-        currencyCode = currencyCode,
-        onClickCurrencies = onClickCurrencies,
+        balanceContent = balanceContent,
         onClickTransfer = onClickTransfer,
         onClickTopUp = onClickTopUp,
         onClickBackup = onClickBackup,
@@ -81,7 +77,7 @@ fun BalanceCard(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
               ) {
-                BalanceValue(balance, currencyCode, onClickCurrencies)
+                balanceContent()
                 VectorIconButton(
                   imageVector = Icons.Default.MoreVert,
                   contentDescription = R.string.action_more_details,
@@ -249,9 +245,7 @@ fun BalanceCardNewUser(onClickTopUp: () -> Unit) {
 @Composable
 fun PreviewBalanceCard() {
   BalanceCard(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur") {} },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},
@@ -265,9 +259,7 @@ fun PreviewBalanceCard() {
 @Composable
 fun PreviewBalanceCardWithoutBackup() {
   BalanceCard(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur") {} },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},
@@ -281,9 +273,7 @@ fun PreviewBalanceCardWithoutBackup() {
 @Composable
 fun PreviewNewWalletBalanceCard() {
   BalanceCard(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur") {} },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardExpandedComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardExpandedComposable.kt
@@ -31,9 +31,7 @@ import com.appcoins.wallet.ui.widgets.component.ButtonWithIcon
 
 @Composable
 fun BalanceCardExpanded(
-  balance: String,
-  currencyCode: String,
-  onClickCurrencies: () -> Unit,
+  balanceContent: @Composable () -> Unit,
   onClickTransfer: () -> Unit,
   onClickTopUp: () -> Unit,
   onClickBackup: () -> Unit,
@@ -61,7 +59,7 @@ fun BalanceCardExpanded(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
           ) {
-            BalanceValue(balance, currencyCode, onClickCurrencies)
+            balanceContent()
             Row {
               ButtonWithIcon(
                 icon = R.drawable.ic_transfer,
@@ -150,9 +148,7 @@ private fun BalanceCardNewUserExpanded(onClickTopUp: () -> Unit) {
 @Composable
 fun PreviewLandscapeBalanceCard() {
   BalanceCardExpanded(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur", {}) },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},
@@ -166,9 +162,7 @@ fun PreviewLandscapeBalanceCard() {
 @Composable
 fun PreviewLandscapeBalanceCardWithoutBackup() {
   BalanceCardExpanded(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur", {}) },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},
@@ -182,9 +176,7 @@ fun PreviewLandscapeBalanceCardWithoutBackup() {
 @Composable
 fun PreviewLandscapeNewWalletBalanceCard() {
   BalanceCardExpanded(
-    balance = "€ 30.12",
-    currencyCode = "Eur",
-    onClickCurrencies = {},
+    balanceContent = { BalanceValue("€ 30.12", "Eur", {}) },
     onClickTransfer = {},
     onClickBackup = {},
     onClickTopUp = {},

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/component/Amount.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/component/Amount.kt
@@ -1,5 +1,6 @@
 package com.appcoins.wallet.ui.widgets.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
@@ -28,6 +29,7 @@ fun BalanceValue(
     Row {
       Text(
         text = balance,
+        modifier = Modifier.clickable(onClick = onClick),
         color = WalletColors.styleguide_white,
         fontSize = 28.sp,
         fontWeight = FontWeight.Bold


### PR DESCRIPTION
**What does this PR do?**

Change the click action of the arrow next to balance to show a bottomsheet with all balances and add this same action when user clicks on balance.

**Database changed?**

  No

**How should this be manually tested?**

  Go to home and click on balance and the arrow next to the balance, it should show a bottomsheet  with all balances.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3982](https://aptoide.atlassian.net/browse/APPC-3982)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-3982]: https://aptoide.atlassian.net/browse/APPC-3982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ