### PR TITLE
feat(ESKL-383): add version check and specific foregroundStart

### DIFF
--- a/legacy/skills/src/main/java/cm/aptoide/skills/games/BackgroundGameService.kt
+++ b/legacy/skills/src/main/java/cm/aptoide/skills/games/BackgroundGameService.kt
@@ -73,7 +73,7 @@ class BackgroundGameService : Service(), GameStateListener {
         getString(R.string.playing_game_notification_body)
       )
       try {
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
           this.startForeground(NOTIFICATION_SERVICE_ID, notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
         }

--- a/legacy/skills/src/main/java/cm/aptoide/skills/games/BackgroundGameService.kt
+++ b/legacy/skills/src/main/java/cm/aptoide/skills/games/BackgroundGameService.kt
@@ -3,8 +3,10 @@ package cm.aptoide.skills.games
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import cm.aptoide.skills.R
 import cm.aptoide.skills.repository.RoomRepository
@@ -14,6 +16,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class BackgroundGameService : Service(), GameStateListener {
   companion object {
+    private const val TAG = "NotificationService"
     private const val NOTIFICATION_SERVICE_ID = 77798
     private const val CHANNEL_ID = "game_notification_channel_id"
     private const val CHANNEL_NAME = "Game Notification Channel"
@@ -69,7 +72,18 @@ class BackgroundGameService : Service(), GameStateListener {
         getString(R.string.playing_game_notification_title),
         getString(R.string.playing_game_notification_body)
       )
-      this.startForeground(NOTIFICATION_SERVICE_ID, notification)
+      try {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+          this.startForeground(NOTIFICATION_SERVICE_ID, notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        }
+        else {
+            this.startForeground(NOTIFICATION_SERVICE_ID, notification)
+          }
+      }
+      catch(exception: Exception){
+        Log.e(TAG, "onStartCommand: Issue starting Notification Service ")
+      }
     }
     return super.onStartCommand(intent, flags, startId)
   }


### PR DESCRIPTION
**What does this PR do?**
Following tests in Android 14, the forgroundService issue persisted in some situations. 
This PR fixes the issue where in a worst case scenario, the service is aborted without error

**Database changed?**

No

**Where should the reviewer start?**

- [ ] BackgroundService

**How should this be manually tested?**

Play a match with Android 14 device

**What are the relevant tickets?**

  Tickets related to this pull-request: [ESKL-383](https://aptoide.atlassian.net/browse/ESKL-383)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[ESKL-383]: https://aptoide.atlassian.net/browse/ESKL-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ