### PR TITLE
[APPC-3869] Skeleton Loading for Home and Rewards

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeFragment.kt
@@ -163,7 +163,7 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
         onClickBackup = { viewModel.onBackupClick() },
         onClickTopUp = { viewModel.onTopUpClick() },
         onClickMenuOptions = { navigator.navigateToManageBottomSheet() },
-        isLoading = viewModel.isLoadingOrIdleBalanceState() && !hasGetSomeValidBalanceResult.value
+        isLoading = (viewModel.isLoadingOrIdleBalanceState() && !hasGetSomeValidBalanceResult.value) || !viewModel.isLoadingTransactions.value
       )
       PromotionsList()
       TransactionsCard(transactionsState = viewModel.uiState.collectAsState().value)
@@ -241,7 +241,7 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
     ) {
       if (viewModel.activePromotions.isEmpty()) {
         item {
-          SkeletonLoadingPromotionCard(hasVerticalList = true)
+          SkeletonLoadingPromotionCards(hasVerticalList = false)
         }
       } else {
         items(viewModel.activePromotions) { promotion ->
@@ -387,11 +387,6 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
 
   private fun setBackup(hasBackup: Async<Boolean>) {
     when (hasBackup) {
-      Async.Uninitialized,
-      is Async.Loading -> {
-        // TODO loading
-      }
-
       is Async.Success -> viewModel.showBackup.value = !(hasBackup.value ?: false)
       else -> Unit
     }
@@ -399,11 +394,6 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
 
   private fun setPromotions(promotionsModel: Async<PromotionsModel>) {
     when (promotionsModel) {
-      Async.Uninitialized,
-      is Async.Loading -> {
-        // TODO loading
-      }
-
       is Async.Success -> {
         viewModel.activePromotions.clear()
         promotionsModel.value!!.perks.forEach { promotion ->
@@ -432,7 +422,6 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
           }
         }
       }
-
       else -> Unit
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeViewModel.kt
@@ -451,6 +451,9 @@ constructor(
         e.printStackTrace()
       }
   }
+  fun isLoadingOrIdleBalanceState(): Boolean {
+    return _uiBalanceState.value == UiBalanceState.Loading || _uiBalanceState.value == UiBalanceState.Idle
+  }
 
   fun updateBalance(uiBalanceState: UiBalanceState) {
     _uiBalanceState.value = uiBalanceState

--- a/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet/home/HomeViewModel.kt
@@ -136,6 +136,7 @@ constructor(
   private val refreshCardNotifications = BehaviorSubject.createDefault(true)
   val showBackup = mutableStateOf(false)
   val newWallet = mutableStateOf(false)
+  val isLoadingTransactions =  mutableStateOf(false)
   val gamesList = mutableStateOf(listOf<GameData>())
   val activePromotions = mutableStateListOf<CardPromotionItem>()
 
@@ -306,6 +307,7 @@ constructor(
           when (result) {
             is ApiSuccess -> {
               newWallet.value = result.data.isEmpty()
+              isLoadingTransactions.value = true
               _uiState.value =
                 Success(
                   result.data
@@ -318,8 +320,8 @@ constructor(
                     .groupBy { it.date.getDay() })
             }
 
-            is ApiFailure -> {}
-            is ApiException -> {}
+            is ApiFailure -> {isLoadingTransactions.value = true}
+            is ApiException -> {isLoadingTransactions.value = true}
             else -> {}
           }
         }

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/GamificationHeaderModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/GamificationHeaderModel.kt
@@ -12,5 +12,24 @@ data class GamificationHeaderModel(
   val bonusPercentage: Double,
   val isVip: Boolean,
   val isMaxVip: Boolean,
-  val walletOrigin: WalletOrigin
-)
+  val walletOrigin: WalletOrigin,
+  val unInitialized: Boolean,
+) {
+
+  companion object {
+    fun emptySkeletonLoadingState() : GamificationHeaderModel {
+      return GamificationHeaderModel(
+        123,
+        null,
+        "",
+        1234,
+        null,
+        1.0,
+        false,
+        false,
+        WalletOrigin.UNKNOWN,
+        true
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/GamificationHeaderModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/GamificationHeaderModel.kt
@@ -13,7 +13,7 @@ data class GamificationHeaderModel(
   val isVip: Boolean,
   val isMaxVip: Boolean,
   val walletOrigin: WalletOrigin,
-  val unInitialized: Boolean,
+  val uninitialized: Boolean,
 ) {
 
   companion object {

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
@@ -196,11 +196,11 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
             GamificationHeaderPartner(
               df.format(this.bonusPercentage)
             )
-          } else if (this != null) {
-            GamificationHeaderNoPurchases()
+          } else if (this != null && this.unInitialized) {
+            SkeletonLoadingGamificationCard()
           }
           else {
-            SkeletonLoadingGamificationCard()
+            GamificationHeaderNoPurchases()
           }
           
           RewardsActions(
@@ -372,6 +372,7 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
             isVip = gamificationStatus == GamificationStatus.VIP,
             isMaxVip = gamificationStatus == GamificationStatus.VIP_MAX,
             walletOrigin = promotionsModel.value?.walletOrigin ?: UNKNOWN,
+            unInitialized = false
           )
       } else {
         viewModel.gamificationHeaderModel.value = null

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
@@ -37,7 +37,9 @@ import com.appcoins.wallet.core.network.backend.model.GamificationStatus
 import com.appcoins.wallet.core.utils.android_common.CurrencyFormatUtils
 import com.appcoins.wallet.feature.challengereward.data.ChallengeRewardManager
 import com.appcoins.wallet.feature.challengereward.data.model.ChallengeRewardFlowPath.REWARDS
+import com.appcoins.wallet.feature.challengereward.data.presentation.ChallengeRewardVisibilityViewModel
 import com.appcoins.wallet.feature.challengereward.data.presentation.challengeRewardNavigation
+import com.appcoins.wallet.feature.challengereward.data.presentation.getLoadingStateChallengeReward
 import com.appcoins.wallet.feature.walletInfo.data.wallet.domain.WalletInfo
 import com.appcoins.wallet.gamification.repository.PromotionsGamificationStats
 import com.appcoins.wallet.ui.common.theme.WalletColors
@@ -50,7 +52,8 @@ import com.appcoins.wallet.ui.widgets.GamificationHeaderPartner
 import com.appcoins.wallet.ui.widgets.PromotionsCardComposable
 import com.appcoins.wallet.ui.widgets.RewardsActions
 import com.appcoins.wallet.ui.widgets.SkeletonLoadingGamificationCard
-import com.appcoins.wallet.ui.widgets.SkeletonLoadingPromotionCard
+import com.appcoins.wallet.ui.widgets.SkeletonLoadingPromotionCards
+import com.appcoins.wallet.ui.widgets.SkeletonLoadingRewardsActionsCard
 import com.appcoins.wallet.ui.widgets.TopBar
 import com.appcoins.wallet.ui.widgets.VipReferralCard
 import com.appcoins.wallet.ui.widgets.openGame
@@ -196,19 +199,23 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
             GamificationHeaderPartner(
               df.format(this.bonusPercentage)
             )
-          } else if (this != null && this.unInitialized) {
+          } else if (this != null && this.uninitialized) {
             SkeletonLoadingGamificationCard()
           }
           else {
             GamificationHeaderNoPurchases()
           }
-          
-          RewardsActions(
-            { navigator.navigateToWithdrawScreen() },
-            { navigator.showPromoCodeFragment() },
-            { navigator.showGiftCardFragment() },
-            challengeRewardNavigation,
-          )
+          if (getLoadingStateChallengeReward()) {
+            SkeletonLoadingRewardsActionsCard()
+          } else {
+            RewardsActions(
+              { navigator.navigateToWithdrawScreen() },
+              { navigator.showPromoCodeFragment() },
+              { navigator.showGiftCardFragment() },
+              challengeRewardNavigation,
+            )
+          }
+
           viewModel.activePromoCode.value?.let { ActivePromoCodeComposable(cardItem = it) }
         }
       }
@@ -221,7 +228,7 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
           modifier = Modifier.padding(top = 16.dp, start = 24.dp, bottom = 6.dp)
         )
         if (viewModel.promotions.isEmpty()) {
-          SkeletonLoadingPromotionCard(hasVerticalList = false)
+          SkeletonLoadingPromotionCards(hasVerticalList = true)
         }
       }
       items(viewModel.promotions) { promotion ->
@@ -372,7 +379,7 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
             isVip = gamificationStatus == GamificationStatus.VIP,
             isMaxVip = gamificationStatus == GamificationStatus.VIP_MAX,
             walletOrigin = promotionsModel.value?.walletOrigin ?: UNKNOWN,
-            unInitialized = false
+            uninitialized = false
           )
       } else {
         viewModel.gamificationHeaderModel.value = null

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
@@ -49,6 +49,8 @@ import com.appcoins.wallet.ui.widgets.GamificationHeaderNoPurchases
 import com.appcoins.wallet.ui.widgets.GamificationHeaderPartner
 import com.appcoins.wallet.ui.widgets.PromotionsCardComposable
 import com.appcoins.wallet.ui.widgets.RewardsActions
+import com.appcoins.wallet.ui.widgets.SkeletonLoadingGamificationCard
+import com.appcoins.wallet.ui.widgets.SkeletonLoadingPromotionCard
 import com.appcoins.wallet.ui.widgets.TopBar
 import com.appcoins.wallet.ui.widgets.VipReferralCard
 import com.appcoins.wallet.ui.widgets.openGame
@@ -194,10 +196,13 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
             GamificationHeaderPartner(
               df.format(this.bonusPercentage)
             )
-          } else {
+          } else if (this != null) {
             GamificationHeaderNoPurchases()
           }
-
+          else {
+            SkeletonLoadingGamificationCard()
+          }
+          
           RewardsActions(
             { navigator.navigateToWithdrawScreen() },
             { navigator.showPromoCodeFragment() },
@@ -213,8 +218,11 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
           fontSize = 14.sp,
           fontWeight = FontWeight.Bold,
           color = WalletColors.styleguide_dark_grey,
-          modifier = Modifier.padding(top = 16.dp, start = 24.dp)
+          modifier = Modifier.padding(top = 16.dp, start = 24.dp, bottom = 6.dp)
         )
+        if (viewModel.promotions.isEmpty()) {
+          SkeletonLoadingPromotionCard(hasVerticalList = false)
+        }
       }
       items(viewModel.promotions) { promotion ->
         Row(modifier = Modifier.padding(horizontal = 16.dp)) {

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardViewModel.kt
@@ -52,7 +52,7 @@ class RewardViewModel @Inject constructor(
 ) : BaseViewModel<RewardState, RewardSideEffect>(initialState()) {
 
   val promotions = mutableStateListOf<CardPromotionItem>()
-  val gamificationHeaderModel = mutableStateOf<GamificationHeaderModel?>(null)
+  val gamificationHeaderModel = mutableStateOf<GamificationHeaderModel?>(GamificationHeaderModel.emptySkeletonLoadingState())
   val vipReferralModel = mutableStateOf<VipReferralInfo?>(null)
   val activePromoCode = mutableStateOf<ActiveCardPromoCodeItem?>(null)
 

--- a/feature/challenge-reward/data/src/main/java/com/appcoins/wallet/feature/challengereward/data/presentation/ChallengeRewardVisibilityViewModel.kt
+++ b/feature/challenge-reward/data/src/main/java/com/appcoins/wallet/feature/challengereward/data/presentation/ChallengeRewardVisibilityViewModel.kt
@@ -17,6 +17,7 @@ class ChallengeRewardVisibilityViewModel(
   private val navigation: () -> Unit,
 ) : ViewModel() {
   private val viewModelState = MutableStateFlow<(() -> Unit)?>(null)
+  val isLoadingChallengerRewardCard = MutableStateFlow(true)
 
   val uiState = viewModelState
     .stateIn(
@@ -36,7 +37,9 @@ class ChallengeRewardVisibilityViewModel(
       }
         .subscribeOn(Schedulers.io())
         .subscribe(
-          { value -> viewModelState.update { value } },
+          { value ->
+            viewModelState.update { value }
+            isLoadingChallengerRewardCard.value = false},
           { Log.e("ChallengeReward", "Failed loading Payment Methods", it) }
         )
     }

--- a/feature/challenge-reward/data/src/main/java/com/appcoins/wallet/feature/challengereward/data/presentation/ViewModelProvider.kt
+++ b/feature/challenge-reward/data/src/main/java/com/appcoins/wallet/feature/challengereward/data/presentation/ViewModelProvider.kt
@@ -3,6 +3,7 @@ package com.appcoins.wallet.feature.challengereward.data.presentation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
@@ -16,10 +17,13 @@ class InjectionsProvider @Inject constructor(
   val bdsRepository: BdsRepository,
 ) : ViewModel()
 
+private val _challengeRewardVisibilityViewModel = mutableStateOf<ChallengeRewardVisibilityViewModel?>(null)
+
+
 @Composable
 fun challengeRewardNavigation(navigation: () -> Unit): (() -> Unit)? {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
-  val vm: ChallengeRewardVisibilityViewModel = viewModel(
+  _challengeRewardVisibilityViewModel.value = viewModel(
     key = "challengeRewardNavigation",
     factory = object : Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -31,6 +35,9 @@ fun challengeRewardNavigation(navigation: () -> Unit): (() -> Unit)? {
       }
     }
   )
-  val uiState by vm.uiState.collectAsState()
+  val uiState by _challengeRewardVisibilityViewModel.value!!.uiState.collectAsState()
   return uiState
+}
+fun getLoadingStateChallengeReward(): Boolean {
+  return _challengeRewardVisibilityViewModel.value?.isLoadingChallengerRewardCard?.value ?: true
 }

--- a/ui/common/src/main/java/com/appcoins/wallet/ui/common/theme/WalletColors.kt
+++ b/ui/common/src/main/java/com/appcoins/wallet/ui/common/theme/WalletColors.kt
@@ -20,4 +20,6 @@ object WalletColors {
   val styleguide_orange = Color(0xFFf86d00)
   val styleguide_vip_yellow = Color(0xFFEFA226)
   val styleguide_vip_yellow_transparent_40 = Color(0x66EFA226)
+  val styleguide_skeleton_loading = Color(0xFF2E2D3C)
+
 }

--- a/ui/widgets/src/aptoide/java/com/appcoins/wallet/ui/widgets/GamesBundleComposable.kt
+++ b/ui/widgets/src/aptoide/java/com/appcoins/wallet/ui/widgets/GamesBundleComposable.kt
@@ -27,15 +27,13 @@ fun GamesBundle(
   fetchFromApiCallback: () -> Unit
 ) {
   fetchFromApiCallback()
-  if (items.isNotEmpty()) {
-    Text(
-      text = stringResource(id = R.string.home_appcoins_compatible_games_title),
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Bold,
-      color = WalletColors.styleguide_dark_grey,
-      modifier = Modifier.padding(top = 27.dp, end = 13.dp, start = 24.dp)
-    )
-  }
+  Text(
+    text = stringResource(id = R.string.home_appcoins_compatible_games_title),
+    fontSize = 14.sp,
+    fontWeight = FontWeight.Bold,
+    color = WalletColors.styleguide_dark_grey,
+    modifier = Modifier.padding(top = 27.dp, end = 13.dp, start = 24.dp)
+  )
   LazyRow(
     modifier = Modifier.padding(
       top = 16.dp
@@ -45,13 +43,6 @@ fun GamesBundle(
   ) {
     if (items.isEmpty()) {
       item {
-        Text(
-          text = stringResource(id = R.string.home_appcoins_compatible_games_title),
-          fontSize = 14.sp,
-          fontWeight = FontWeight.Bold,
-          color = WalletColors.styleguide_dark_grey,
-          modifier = Modifier.padding(top = 27.dp, end = 13.dp, start = 24.dp)
-        )
         SkeletonLoadingGamesBundleCard()
       }
     } else {

--- a/ui/widgets/src/aptoide/java/com/appcoins/wallet/ui/widgets/GamesBundleComposable.kt
+++ b/ui/widgets/src/aptoide/java/com/appcoins/wallet/ui/widgets/GamesBundleComposable.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -34,13 +35,26 @@ fun GamesBundle(
       color = WalletColors.styleguide_dark_grey,
       modifier = Modifier.padding(top = 27.dp, end = 13.dp, start = 24.dp)
     )
-    LazyRow(
-      modifier = Modifier.padding(
-        top = 16.dp
-      ),
-      contentPadding = PaddingValues(horizontal = 16.dp),
-      horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
+  }
+  LazyRow(
+    modifier = Modifier.padding(
+      top = 16.dp
+    ),
+    contentPadding = PaddingValues(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(16.dp)
+  ) {
+    if (items.isEmpty()) {
+      item {
+        Text(
+          text = stringResource(id = R.string.home_appcoins_compatible_games_title),
+          fontSize = 14.sp,
+          fontWeight = FontWeight.Bold,
+          color = WalletColors.styleguide_dark_grey,
+          modifier = Modifier.padding(top = 27.dp, end = 13.dp, start = 24.dp)
+        )
+        SkeletonLoadingGamesBundleCard()
+      }
+    } else {
       items(items) { item ->
         CardItem(gameCardData = item)
       }
@@ -163,6 +177,62 @@ data class GameData(
   val actionUrl: String?
 )
 
+@Composable
+fun SkeletonLoadingGamesBundleCard() {
+  Card(
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .clip(shape = RoundedCornerShape(8.dp))
+      .width(332.dp)
+      .height(150.dp)
+  ) {
+    Box(
+      modifier = Modifier.fillMaxSize()
+    ) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+      ) {
+        Spacer(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(130.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+      }
+      Box(
+        modifier = Modifier
+          .align(Alignment.BottomStart)
+          .background(WalletColors.styleguide_blue_secondary)
+      ) {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.Bottom
+        ) {
+          Spacer(
+            modifier = Modifier
+              .padding(top = 8.dp, bottom = 8.dp, start = 8.dp)
+              .size(62.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 170.dp)
+              .height(height = 30.dp)
+              .padding(start = 8.dp, bottom = 8.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+      }
+    }
+  }
+}
+
 @Preview
 @Composable
 fun PreviewGamesBundle() {
@@ -185,4 +255,10 @@ fun PreviewGamesBundle() {
     ),
     {}
   )
+}
+
+@Preview
+@Composable
+fun PreviewSkeletonLoadingGamesBundle() {
+  SkeletonLoadingGamesBundleCard()
 }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
@@ -211,7 +211,7 @@ fun SkeletonLoadingBalanceCard() {
       )
       Spacer(
         modifier = Modifier
-          .padding(top = 14.dp)
+          .padding(top = 8.dp)
           .width(width = 120.dp)
           .height(height = 40.dp)
           .clip(RoundedCornerShape(50.dp))

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
@@ -59,7 +59,8 @@ fun BalanceCard(
         onClickBackup = onClickBackup,
         onClickMenuOptions = onClickMenuOptions,
         showBackup = showBackup,
-        newWallet = newWallet
+        newWallet = newWallet,
+        isLoading = isLoading
       )
     } else if (isLoading) {
       SkeletonLoadingBalanceCard()

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardComposable.kt
@@ -1,5 +1,6 @@
 package com.appcoins.wallet.ui.widgets
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -46,7 +47,8 @@ fun BalanceCard(
   onClickBackup: () -> Unit,
   onClickMenuOptions: () -> Unit,
   showBackup: Boolean = true,
-  newWallet: Boolean = true
+  newWallet: Boolean = true,
+  isLoading: Boolean = true,
 ) {
   BoxWithConstraints {
     if (expanded()) {
@@ -59,6 +61,8 @@ fun BalanceCard(
         showBackup = showBackup,
         newWallet = newWallet
       )
+    } else if (isLoading) {
+      SkeletonLoadingBalanceCard()
     } else {
       Card(
         colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
@@ -171,6 +175,53 @@ fun TotalBalance(
 }
 
 @Composable
+fun SkeletonLoadingBalanceCard() {
+  Card(
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .padding(top = 16.dp, bottom = 0.dp, start = 16.dp, end = 16.dp)
+      .clip(shape = RoundedCornerShape(8.dp))
+  ) {
+    Column(modifier = Modifier.padding(32.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+      Spacer(
+        modifier = Modifier
+          .padding(top = 16.dp)
+          .width(width = 250.dp)
+          .height(height = 30.dp)
+          .clip(RoundedCornerShape(5.dp))
+          .background(brush = shimmerSkeleton()),
+      )
+      Spacer(
+        modifier = Modifier
+          .padding(top = 16.dp)
+          .width(width = 350.dp)
+          .height(height = 22.dp)
+          .clip(RoundedCornerShape(5.dp))
+          .background(brush = shimmerSkeleton()),
+      )
+      Spacer(
+        modifier = Modifier
+          .padding(bottom = 16.dp, top = 2.dp)
+          .width(width = 270.dp)
+          .height(height = 22.dp)
+          .clip(RoundedCornerShape(5.dp))
+          .background(brush = shimmerSkeleton()),
+      )
+      Spacer(
+        modifier = Modifier
+          .padding(top = 14.dp)
+          .width(width = 120.dp)
+          .height(height = 40.dp)
+          .clip(RoundedCornerShape(50.dp))
+          .background(brush = shimmerSkeleton())
+      )
+    }
+  }
+}
+
+@Composable
 fun BalanceItem(icon: Int, currencyName: Int, balance: String) {
   Card(
     colors = CardDefaults.cardColors(containerColor = WalletColors.styleguide_blue),
@@ -251,7 +302,8 @@ fun PreviewBalanceCard() {
     onClickTopUp = {},
     onClickMenuOptions = {},
     showBackup = true,
-    newWallet = false
+    newWallet = false,
+    isLoading = false
   )
 }
 
@@ -265,7 +317,8 @@ fun PreviewBalanceCardWithoutBackup() {
     onClickTopUp = {},
     onClickMenuOptions = {},
     showBackup = false,
-    newWallet = false
+    newWallet = false,
+    isLoading = false
   )
 }
 
@@ -279,7 +332,8 @@ fun PreviewNewWalletBalanceCard() {
     onClickTopUp = {},
     onClickMenuOptions = {},
     showBackup = true,
-    newWallet = true
+    newWallet = true,
+    isLoading = false
   )
 }
 
@@ -301,4 +355,9 @@ fun PreviewBalanceItems() {
     BalanceItem(R.drawable.ic_appc_c_token, R.string.appc_credits_token_name, "5244 APPC-C")
     BalanceItem(R.drawable.ic_eth_token, R.string.ethereum_token_name, "5244 ETH")
   }
+}
+@Preview
+@Composable
+fun PreviewSkeletonLoading() {
+  SkeletonLoadingBalanceCard()
 }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardExpandedComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceCardExpandedComposable.kt
@@ -1,13 +1,16 @@
 package com.appcoins.wallet.ui.widgets
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
@@ -37,7 +40,8 @@ fun BalanceCardExpanded(
   onClickBackup: () -> Unit,
   onClickMenuOptions: () -> Unit,
   showBackup: Boolean = true,
-  newWallet: Boolean = true
+  newWallet: Boolean = true,
+  isLoading: Boolean = true,
 ) {
   Card(
     colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
@@ -46,7 +50,10 @@ fun BalanceCardExpanded(
       .padding(16.dp)
       .clip(shape = RoundedCornerShape(8.dp))
   ) {
-    if (newWallet) {
+    if (isLoading) {
+      SkeletonLoadingBalanceCardExpanded()
+    }
+    else if (newWallet) {
       BalanceCardNewUserExpanded(onClickTopUp = onClickTopUp)
     } else {
       Column {
@@ -143,6 +150,50 @@ private fun BalanceCardNewUserExpanded(onClickTopUp: () -> Unit) {
   }
 }
 
+@Composable
+fun SkeletonLoadingBalanceCardExpanded() {
+  Card(
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .padding(bottom = 0.dp, start = 16.dp, end = 16.dp)
+      .clip(shape = RoundedCornerShape(8.dp))
+  ) {
+    Row(
+      modifier = Modifier
+        .padding(32.dp)
+        .fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+      Column{
+        Spacer(
+          modifier = Modifier
+            .width(width = 250.dp)
+            .height(height = 30.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 4.dp)
+            .width(width = 500.dp)
+            .height(height = 22.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+      }
+      Spacer(
+        modifier = Modifier
+          .width(width = 120.dp)
+          .height(height = 40.dp)
+          .clip(RoundedCornerShape(50.dp))
+          .background(brush = shimmerSkeleton())
+      )
+    }
+  }
+}
+
 
 @Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Composable
@@ -154,7 +205,8 @@ fun PreviewLandscapeBalanceCard() {
     onClickTopUp = {},
     onClickMenuOptions = {},
     showBackup = true,
-    newWallet = false
+    newWallet = false,
+    isLoading = false,
   )
 }
 
@@ -168,7 +220,8 @@ fun PreviewLandscapeBalanceCardWithoutBackup() {
     onClickTopUp = {},
     onClickMenuOptions = {},
     showBackup = false,
-    newWallet = false
+    newWallet = false,
+    isLoading = false
   )
 }
 
@@ -183,5 +236,22 @@ fun PreviewLandscapeNewWalletBalanceCard() {
     onClickMenuOptions = {},
     showBackup = true,
     newWallet = true,
+    isLoading = false
   )
 }
+
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
+@Composable
+fun PreviewSkeletonBalanceCardExpanded() {
+  BalanceCardExpanded(
+    balanceContent = { BalanceValue("€ 30.12", "Eur", {}) },
+    onClickTransfer = {},
+    onClickBackup = {},
+    onClickTopUp = {},
+    onClickMenuOptions = {},
+    showBackup = true,
+    newWallet = true,
+    isLoading = true,
+  )
+}
+

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -74,7 +74,7 @@ private fun CardVerticalItemExample() {
 @Preview
 @Composable
 private fun LoadingPromotionCard() {
-  SkeletonLoadingPromotionCard(hasVerticalList = true)
+  SkeletonLoadingPromotionCards(hasVerticalList = false)
 }
 
 
@@ -362,16 +362,22 @@ fun ImageWithTitleAndDescription(
 }
 
 @Composable
-fun SkeletonLoadingPromotionCard(hasVerticalList: Boolean) {
-  val maxColumnWidth = if (hasVerticalList) 300.dp else 240.dp
-  val horizontalPadding = if (hasVerticalList) 0.dp else 16.dp
+fun SkeletonLoadingPromotionCards(hasVerticalList: Boolean) {
+  SkeletonLoadingPromotionCardItem(hasVerticalList)
+  SkeletonLoadingPromotionCardItem(hasVerticalList)
+  SkeletonLoadingPromotionCardItem(hasVerticalList)
+}
+
+@Composable
+private fun SkeletonLoadingPromotionCardItem(hasVerticalList: Boolean) {
+  val maxColumnWidth = if (hasVerticalList) 320.dp else 300.dp
   Card(
     colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
     modifier =
     Modifier
       .fillMaxWidth()
       .width(maxColumnWidth)
-      .padding(horizontal = horizontalPadding)
+      .padding(top = 16.dp, start = if (hasVerticalList) 16.dp else 0.dp, end = if (hasVerticalList) 16.dp else 16.dp)
       .clip(shape = RoundedCornerShape(8.dp))
   ) {
     Column( modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
@@ -391,7 +397,7 @@ fun SkeletonLoadingPromotionCard(hasVerticalList: Boolean) {
         ) {
           Spacer(
             modifier = Modifier
-              .width(width = 130.dp)
+              .width(width = 120.dp)
               .height(height = 22.dp)
               .clip(RoundedCornerShape(5.dp))
               .background(brush = shimmerSkeleton()),

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -364,12 +364,14 @@ fun ImageWithTitleAndDescription(
 @Composable
 fun SkeletonLoadingPromotionCard(hasVerticalList: Boolean) {
   val maxColumnWidth = if (hasVerticalList) 300.dp else 240.dp
+  val horizontalPadding = if (hasVerticalList) 0.dp else 16.dp
   Card(
     colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
     modifier =
     Modifier
       .fillMaxWidth()
       .width(maxColumnWidth)
+      .padding(horizontal = horizontalPadding)
       .clip(shape = RoundedCornerShape(8.dp))
   ) {
     Column( modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
@@ -389,14 +391,14 @@ fun SkeletonLoadingPromotionCard(hasVerticalList: Boolean) {
         ) {
           Spacer(
             modifier = Modifier
-              .width(width = 100.dp)
+              .width(width = 130.dp)
               .height(height = 22.dp)
               .clip(RoundedCornerShape(5.dp))
               .background(brush = shimmerSkeleton()),
           )
           Spacer(
             modifier = Modifier
-              .width(width = 180.dp)
+              .width(width = 200.dp)
               .height(height = 27.dp)
               .padding(top = 5.dp, end = 16.dp)
               .clip(RoundedCornerShape(5.dp))

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -71,6 +71,12 @@ private fun CardVerticalItemExample() {
   PromotionsCardComposable(cardItem = verticalCardItem)
 }
 
+@Preview
+@Composable
+private fun LoadingPromotionCard() {
+  SkeletonLoadingPromotionCard(hasVerticalList = true)
+}
+
 
 @Composable
 fun PromotionsCardComposable(cardItem: CardPromotionItem) {
@@ -349,6 +355,90 @@ fun ImageWithTitleAndDescription(
           style = MaterialTheme.typography.bodyMedium,
           color = WalletColors.styleguide_white,
           modifier = Modifier.padding(top = 4.dp, end = 8.dp)
+        )
+      }
+    }
+  }
+}
+
+@Composable
+fun SkeletonLoadingPromotionCard(hasVerticalList: Boolean) {
+  val maxColumnWidth = if (hasVerticalList) 300.dp else 240.dp
+  Card(
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .width(maxColumnWidth)
+      .clip(shape = RoundedCornerShape(8.dp))
+  ) {
+    Column( modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(56.dp)
+            .height(56.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Column(
+          modifier = Modifier
+            .width(240.dp)
+            .padding(start = 12.dp)
+        ) {
+          Spacer(
+            modifier = Modifier
+              .width(width = 100.dp)
+              .height(height = 22.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 180.dp)
+              .height(height = 27.dp)
+              .padding(top = 5.dp, end = 16.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+      }
+      Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 16.dp, end = 16.dp)) {
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(40.dp)
+            .padding(end = 6.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(40.dp)
+            .padding(end = 6.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(40.dp)
+            .padding(end = 6.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(40.dp)
+            .height(40.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(brush = shimmerSkeleton()),
         )
       }
     }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
@@ -3,11 +3,14 @@ package com.appcoins.wallet.ui.widgets
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -21,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -116,6 +120,71 @@ fun ActionCard(
   }
 }
 
+
+@Composable
+fun SkeletonLoadingRewardsActionsCard() {
+  val scrollState = rememberScrollState()
+  Row(
+    modifier = Modifier
+      .horizontalScroll(scrollState)
+      .padding(horizontal = 16.dp)
+      .padding(top = 24.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    SkeletonLoadingRewardActionCard()
+    SkeletonLoadingRewardActionCard()
+    SkeletonLoadingRewardActionCard()
+  }
+}
+@Composable
+private fun SkeletonLoadingRewardActionCard() {
+  Card(
+    modifier = Modifier
+      .size(width = 160.dp, height = 208.dp),
+    shape = RoundedCornerShape(8.dp),
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+  ) {
+    Column(
+      modifier = Modifier.padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Spacer(
+        modifier = Modifier
+          .height(60.dp)
+          .width(60.dp)
+          .clip(RoundedCornerShape(30.dp))
+          .background(brush = shimmerSkeleton()),
+      )
+      Column( horizontalAlignment = Alignment.CenterHorizontally) {
+        Spacer(
+          modifier = Modifier
+            .width(width = 110.dp)
+            .height(height = 20.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 16.dp)
+            .width(width = 160.dp)
+            .height(height = 17.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(width = 90.dp)
+            .height(height = 17.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush = shimmerSkeleton())
+        )
+      }
+    }
+  }
+}
+
 @Preview
 @Composable
 private fun PreviewRewardsActions() {
@@ -125,4 +194,11 @@ private fun PreviewRewardsActions() {
     { },
     { },
   )
+}
+
+
+@Preview
+@Composable
+private fun PreviewSkeletonRewardsActions() {
+  SkeletonLoadingRewardsActionsCard()
 }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
@@ -384,7 +384,7 @@ fun SkeletonLoadingGamificationCard() {
       .padding(start = 16.dp, end = 16.dp, top = 16.dp)
       .clip(shape = RoundedCornerShape(8.dp))
   ) {
-    Column(modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+    Column(modifier = Modifier.padding(start = 8.dp, bottom = 16.dp)) {
       Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -395,14 +395,14 @@ fun SkeletonLoadingGamificationCard() {
         Column {
           Spacer(
             modifier = Modifier
-              .width(width = 170.dp)
+              .width(width = 150.dp)
               .height(height = 22.dp)
               .clip(RoundedCornerShape(5.dp))
               .background(brush = shimmerSkeleton()),
           )
           Spacer(
             modifier = Modifier
-              .width(width = 250.dp)
+              .width(width = 230.dp)
               .height(height = 30.dp)
               .padding(top = 8.dp)
               .clip(RoundedCornerShape(5.dp))
@@ -411,8 +411,8 @@ fun SkeletonLoadingGamificationCard() {
         }
         Spacer(
           modifier = Modifier
-            .size(70.dp)
-            .clip(RoundedCornerShape(35.dp))
+            .size(90.dp)
+            .clip(RoundedCornerShape(45.dp))
             .background(brush = shimmerSkeleton()),
         )
       }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -343,8 +344,10 @@ fun VipReferralCard(onClick: () -> Unit, vipBonus: String) {
           .width(64.dp)
           .align(Alignment.CenterVertically)
       )
-      Column(modifier = Modifier
-        .weight(1f)) {
+      Column(
+        modifier = Modifier
+          .weight(1f)
+      ) {
         Text(
           text = stringResource(R.string.vip_program_referral_button_title),
           style = MaterialTheme.typography.titleMedium,
@@ -368,6 +371,63 @@ fun VipReferralCard(onClick: () -> Unit, vipBonus: String) {
           .width(36.dp)
       )
     }
+  }
+}
+
+@Composable
+fun SkeletonLoadingGamificationCard() {
+  Card(
+    colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+      .clip(shape = RoundedCornerShape(8.dp))
+  ) {
+    Column(modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(top = 8.dp, start = 8.dp, end = 8.dp)
+      ) {
+        Column {
+          Spacer(
+            modifier = Modifier
+              .width(width = 170.dp)
+              .height(height = 22.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 250.dp)
+              .height(height = 30.dp)
+              .padding(top = 8.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+        Spacer(
+          modifier = Modifier
+            .size(70.dp)
+            .clip(RoundedCornerShape(35.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+      }
+    }
+    Row(
+      modifier = Modifier.fillMaxWidth()
+    ) {
+      Spacer(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(50.dp)
+          .background(brush = shimmerSkeleton()),
+      )
+    }
+
   }
 }
 
@@ -421,4 +481,10 @@ fun PreviewRewardsGamificationPartner() {
 @Composable
 fun PreviewRewardsVip() {
   VipReferralCard({}, "5")
+}
+
+@Preview
+@Composable
+fun PreviewRewardsSkeletonLoading() {
+  SkeletonLoadingGamificationCard()
 }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/ShimmerSkeletonComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/ShimmerSkeletonComposable.kt
@@ -1,0 +1,43 @@
+package com.appcoins.wallet.ui.widgets
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import com.appcoins.wallet.ui.common.theme.WalletColors
+
+@Composable
+fun shimmerSkeleton(showShimmer: Boolean = true,targetValue:Float = 1000f): Brush {
+  return if (showShimmer) {
+    val shimmerColors = listOf(
+      WalletColors.styleguide_skeleton_loading.copy(alpha = 0.8f),
+      WalletColors.styleguide_skeleton_loading.copy(alpha = 0.2f),
+      WalletColors.styleguide_skeleton_loading.copy(alpha = 0.8f),
+    )
+
+    val transition = rememberInfiniteTransition(label = "")
+    val translateAnimation = transition.animateFloat(
+      initialValue = 0f,
+      targetValue = targetValue,
+      animationSpec = infiniteRepeatable(
+        animation = tween(800), repeatMode = RepeatMode.Reverse
+      ), label = ""
+    )
+    Brush.linearGradient(
+      colors = shimmerColors,
+      start = Offset.Zero,
+      end = Offset(x = translateAnimation.value, y = translateAnimation.value)
+    )
+  } else {
+    Brush.linearGradient(
+      colors = listOf(Color.Transparent,Color.Transparent),
+      start = Offset.Zero,
+      end = Offset.Zero
+    )
+  }
+}

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/TransactionsComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/TransactionsComposable.kt
@@ -1,5 +1,6 @@
 package com.appcoins.wallet.ui.widgets
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -7,8 +8,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -129,9 +132,11 @@ fun TransactionCard(
 
 @Composable
 fun TransactionSeparator(text: String) {
-  Row(modifier = Modifier
-    .fillMaxWidth()
-    .padding(top = 16.dp, bottom = 8.dp, start = 8.dp)) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 16.dp, bottom = 8.dp, start = 8.dp)
+  ) {
     Text(
       text = text,
       color = styleguide_dark_grey,
@@ -346,6 +351,117 @@ fun IconTextButton(text: String, iconId: Int, onClick: () -> Unit = {}) {
   }
 }
 
+@Composable
+fun SkeletonLoadingTransactionCard() {
+  Card(
+    colors = CardDefaults.cardColors(styleguide_blue_secondary),
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .clip(shape = RoundedCornerShape(8.dp))
+  ) {
+    Column(modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+      Row(verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()) {
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(46.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Row(verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+          modifier = Modifier.fillMaxWidth()) {
+          Spacer(
+            modifier = Modifier
+              .width(width = 170.dp)
+              .height(height = 22.dp)
+              .padding(start = 8.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 90.dp)
+              .height(height = 22.dp)
+              .padding(end = 16.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+      }
+    }
+    Column(modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+      Row(verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()) {
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(46.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Row(verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+          modifier = Modifier.fillMaxWidth()) {
+          Spacer(
+            modifier = Modifier
+              .width(width = 170.dp)
+              .height(height = 22.dp)
+              .padding(start = 8.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 90.dp)
+              .height(height = 22.dp)
+              .padding(end = 16.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+      }
+    }
+    Column(modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {
+      Row(verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()) {
+        Spacer(
+          modifier = Modifier
+            .padding(top = 8.dp)
+            .width(46.dp)
+            .height(46.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(brush = shimmerSkeleton()),
+        )
+        Row(verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+          modifier = Modifier.fillMaxWidth()) {
+          Spacer(
+            modifier = Modifier
+              .width(width = 170.dp)
+              .height(height = 22.dp)
+              .padding(start = 8.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+          Spacer(
+            modifier = Modifier
+              .width(width = 90.dp)
+              .height(height = 22.dp)
+              .padding(end = 16.dp)
+              .clip(RoundedCornerShape(5.dp))
+              .background(brush = shimmerSkeleton()),
+          )
+        }
+      }
+    }
+  }
+}
+
 @Preview
 @Composable
 fun PreviewTransactionCardHeader() {
@@ -407,4 +523,10 @@ fun PreviewTransactionSeparator() {
 @Composable
 fun PreviewDownloadButton() {
   IconTextButton(text = "Download", R.drawable.ic_download)
+}
+
+@Preview
+@Composable
+private fun LoadingTransactionCard() {
+  SkeletonLoadingTransactionCard()
 }


### PR DESCRIPTION
**What does this PR do?**

   Add Skeleton Loading for Home and Rewards Fragments to show a loading

**Database changed?**

   No

**How should this be manually tested?**

 Open Home and Rewards with bad connection

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3869](https://aptoide.atlassian.net/browse/APPC-3869)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-3869]: https://aptoide.atlassian.net/browse/APPC-3869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ