### PR TITLE
[APPC-4040] Indicative confirmation event for AppCoins Credits payments

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
@@ -127,6 +127,7 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
   }
 
   override fun finish(uid: String?, purchaseUid: String) {
+    presenter.sendPaymentConfirmationEvent()
     presenter.sendPaymentEvent()
     presenter.sendRevenueEvent()
     presenter.sendPaymentSuccessEvent(purchaseUid)
@@ -146,6 +147,7 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
   }
 
   override fun finish(purchase: Purchase, orderReference: String?) {
+    presenter.sendPaymentConfirmationEvent()
     presenter.sendPaymentEvent()
     presenter.sendRevenueEvent()
     presenter.sendPaymentSuccessEvent(purchase.uid)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.kt
@@ -94,7 +94,8 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
 
   override fun showLoading() {
     binding.genericErrorLayout.genericPurchaseErrorLayout.visibility = View.GONE
-    binding.fragmentIabTransactionCompleted.iabActivityTransactionCompleted.visibility = View.INVISIBLE
+    binding.fragmentIabTransactionCompleted.iabActivityTransactionCompleted.visibility =
+      View.INVISIBLE
     binding.loadingAnimation.visibility = View.VISIBLE
     binding.makingPurchaseText.visibility = View.VISIBLE
   }
@@ -113,15 +114,18 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
 
   override fun getOkErrorClick() = RxView.clicks(binding.genericErrorLayout.errorDismiss)
 
-  override fun getSupportIconClick() = RxView.clicks(binding.genericErrorLayout.genericErrorLayout.layoutSupportIcn)
+  override fun getSupportIconClick() =
+    RxView.clicks(binding.genericErrorLayout.genericErrorLayout.layoutSupportIcn)
 
-  override fun getSupportLogoClick() = RxView.clicks(binding.genericErrorLayout.genericErrorLayout.layoutSupportLogo)
+  override fun getSupportLogoClick() =
+    RxView.clicks(binding.genericErrorLayout.genericErrorLayout.layoutSupportLogo)
 
   override fun close() = iabView.close(billingMessagesMapper.mapCancellation())
 
   override fun showError(message: Int?) {
     binding.genericErrorLayout.errorDismiss.setText(getString(R.string.back_button))
-    binding.genericErrorLayout.genericErrorLayout.errorMessage.text = getString(message ?: R.string.activity_iab_error_message)
+    binding.genericErrorLayout.genericErrorLayout.errorMessage.text =
+      getString(message ?: R.string.activity_iab_error_message)
     binding.genericErrorLayout.genericPurchaseErrorLayout.visibility = View.VISIBLE
     hideLoading()
   }
@@ -165,11 +169,13 @@ class AppcoinsRewardsBuyFragment : BasePageViewFragment(), AppcoinsRewardsBuyVie
     binding.loadingAnimation.visibility = View.GONE
     binding.makingPurchaseText.visibility = View.GONE
     binding.genericErrorLayout.genericPurchaseErrorLayout.visibility = View.GONE
-    binding.fragmentIabTransactionCompleted.iabActivityTransactionCompleted.visibility = View.VISIBLE
+    binding.fragmentIabTransactionCompleted.iabActivityTransactionCompleted.visibility =
+      View.VISIBLE
     binding.fragmentIabTransactionCompleted.bonusSuccessLayout.visibility = View.GONE
   }
 
-  override fun getAnimationDuration() = binding.fragmentIabTransactionCompleted.lottieTransactionSuccess.duration * 2
+  override fun getAnimationDuration() =
+    binding.fragmentIabTransactionCompleted.lottieTransactionSuccess.duration * 2
 
   override fun lockRotation() = iabView.lockRotation()
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
@@ -16,21 +16,21 @@ import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 
 class AppcoinsRewardsBuyPresenter(
-    private val view: AppcoinsRewardsBuyView,
-    private val rewardsManager: RewardsManager,
-    private val viewScheduler: Scheduler,
-    private val networkScheduler: Scheduler,
-    private val disposables: CompositeDisposable,
-    private val packageName: String,
-    private val isBds: Boolean,
-    private val isPreSelected: Boolean,
-    private val analytics: BillingAnalytics,
-    private val paymentAnalytics: PaymentMethodsAnalytics,
-    private val transactionBuilder: TransactionBuilder,
-    private val formatter: CurrencyFormatUtils,
-    private val gamificationLevel: Int,
-    private val appcoinsRewardsBuyInteract: AppcoinsRewardsBuyInteract,
-    private val logger: Logger
+  private val view: AppcoinsRewardsBuyView,
+  private val rewardsManager: RewardsManager,
+  private val viewScheduler: Scheduler,
+  private val networkScheduler: Scheduler,
+  private val disposables: CompositeDisposable,
+  private val packageName: String,
+  private val isBds: Boolean,
+  private val isPreSelected: Boolean,
+  private val analytics: BillingAnalytics,
+  private val paymentAnalytics: PaymentMethodsAnalytics,
+  private val transactionBuilder: TransactionBuilder,
+  private val formatter: CurrencyFormatUtils,
+  private val gamificationLevel: Int,
+  private val appcoinsRewardsBuyInteract: AppcoinsRewardsBuyInteract,
+  private val logger: Logger
 ) {
 
   companion object {
@@ -117,7 +117,13 @@ class AppcoinsRewardsBuyPresenter(
             .flatMapCompletable { purchase ->
               Completable.fromAction { view.showTransactionCompleted() }
                 .subscribeOn(viewScheduler)
-                .andThen(Completable.timer(view.getAnimationDuration(), TimeUnit.MILLISECONDS, viewScheduler))
+                .andThen(
+                  Completable.timer(
+                    view.getAnimationDuration(),
+                    TimeUnit.MILLISECONDS,
+                    viewScheduler
+                  )
+                )
                 .andThen(Completable.fromAction { appcoinsRewardsBuyInteract.removeAsyncLocalPayment() })
                 .andThen(Completable.fromAction {
                   view.finish(purchase, transaction.orderReference)
@@ -136,8 +142,19 @@ class AppcoinsRewardsBuyPresenter(
             .flatMapCompletable { transactionModel ->
               Completable.fromAction { view.showTransactionCompleted() }
                 .subscribeOn(viewScheduler)
-                .andThen(Completable.timer(view.getAnimationDuration(), TimeUnit.MILLISECONDS, viewScheduler))
-                .andThen(Completable.fromAction { view.finish(transactionModel.txId, transactionModel.txId ?: "") })
+                .andThen(
+                  Completable.timer(
+                    view.getAnimationDuration(),
+                    TimeUnit.MILLISECONDS,
+                    viewScheduler
+                  )
+                )
+                .andThen(Completable.fromAction {
+                  view.finish(
+                    transactionModel.txId,
+                    transactionModel.txId ?: ""
+                  )
+                })
             }
         }
       }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.kt
@@ -220,6 +220,18 @@ class AppcoinsRewardsBuyPresenter(
     )
   }
 
+  fun sendPaymentConfirmationEvent() {
+    analytics.sendPaymentConfirmationEvent(
+      packageName = packageName,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = BillingAnalytics.PAYMENT_METHOD_REWARDS,
+      transactionType = transactionBuilder.type,
+      action = BillingAnalytics.ACTION_BUY
+    )
+  }
+
+
   fun sendPaymentSuccessEvent(txId: String) {
     paymentAnalytics.stopTimingForPurchaseEvent(
       PaymentMethodsAnalytics.PAYMENT_METHOD_APPC,


### PR DESCRIPTION
**What does this PR do?**
Adds the wallet_payment_confirmation to AppCoinsCredits payments. The event is sent right before the wallet_payment_conclusion.

**Database changed?**
No

**Where should the reviewer start?**
Only first commit.

**What are the relevant tickets?**
https://aptoide.atlassian.net/browse/APPC-4040

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
