### PR TITLE
Fix[APPC 4086] bottom navigation hidden or smashed

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
@@ -1,10 +1,12 @@
 package com.asfoundation.wallet.recover.success
 
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import by.kirich1409.viewbindingdelegate.viewBinding
@@ -12,11 +14,13 @@ import com.asf.wallet.R
 import com.appcoins.wallet.core.arch.SideEffect
 import com.appcoins.wallet.core.arch.SingleStateFragment
 import com.appcoins.wallet.core.arch.ViewState
+import com.appcoins.wallet.core.utils.android_common.AppUtils
 import com.asf.wallet.databinding.RecoveryWalletSuccessBottomSheetLayoutBinding
 import com.asfoundation.wallet.recover.entry.RecoverEntryNavigator
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -53,11 +57,17 @@ class RecoveryWalletSuccessBottomSheetFragment : BottomSheetDialogFragment(),
 
     views.recoveryWalletBottomButton.setOnClickListener {
       if (requireArguments().getSerializable(IS_FROM_ONBOARDING) as Boolean) {
-        navigator.navigateToNavBarGraph(navController())
+        restart(requireContext())
       } else {
         navigator.navigateBack()
+        dismiss()
       }
-      dismiss()
+    }
+  }
+
+  private fun restart(context: Context) {
+    lifecycleScope.launch {
+      AppUtils.restartApp(context)
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

  Fixed redirect into recovery wallet to homeFragment for prevent hidden bottom navigation
  
**Database changed?**

    No

**How should this be manually tested?**

Try recovery wallet on onbarding and inside wallet.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4086](https://aptoide.atlassian.net/browse/APPC-4086)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4086]: https://aptoide.atlassian.net/browse/APPC-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ