### PR TITLE
Feat[APPC-4095]  Analytics Identify if users have GamesHub installed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <package android:name="com.phonepe.app" />
     <package android:name="in.org.npci.upiapp" />
     <package android:name="id.dana" />
+    <package android:name="com.dti.folderlauncher" />
   </queries>
 
   <application

--- a/app/src/main/java/com/asfoundation/wallet/analytics/IndicativeInitializeWrapper.kt
+++ b/app/src/main/java/com/asfoundation/wallet/analytics/IndicativeInitializeWrapper.kt
@@ -7,5 +7,5 @@ import com.appcoins.wallet.feature.promocode.data.repository.PromoCode
 data class IndicativeInitializeWrapper(
     val installerPackage: String, val level: Int,
     val hasGms: Boolean, val walletAddress: String,
-    val promoCode: com.appcoins.wallet.feature.promocode.data.repository.PromoCode, val deviceInfo: DeviceInformation
+    val promoCode: com.appcoins.wallet.feature.promocode.data.repository.PromoCode, val deviceInfo: DeviceInformation, val ghOemId: String
 )

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/AnalyticsLabels.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/AnalyticsLabels.kt
@@ -15,4 +15,5 @@ object AnalyticsLabels {
   const val LANGUAGE = "language"
   const val IS_EMULATOR = "probably_emulator"
   const val DEVICE_ORIENTATION = "device_orientation"
+  const val GAMES_HUB_OEMID = "gh_oemid"
 }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/IndicativeAnalytics.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/IndicativeAnalytics.kt
@@ -3,6 +3,7 @@ package com.appcoins.wallet.core.analytics.analytics
 import android.content.Context
 import android.content.res.Configuration
 import com.appcoins.wallet.core.analytics.BuildConfig
+import com.appcoins.wallet.core.analytics.analytics.partners.PartnerAddressService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import it.czerwinski.android.hilt.annotations.BoundTo
 import org.json.JSONObject
@@ -56,7 +57,8 @@ class IndicativeAnalytics @Inject constructor(
     brand: String,
     model: String,
     language: String,
-    isEmulator: Boolean
+    isEmulator: Boolean,
+    ghOemId: String
   ) {
 
     val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
@@ -79,6 +81,8 @@ class IndicativeAnalytics @Inject constructor(
     superProperties.put(AnalyticsLabels.MODEL, model)
     superProperties.put(AnalyticsLabels.LANGUAGE, language)
     superProperties.put(AnalyticsLabels.IS_EMULATOR, isEmulator)
+    superProperties.put(AnalyticsLabels.GAMES_HUB_OEMID, ghOemId)
+
 
     if (userId.isNotEmpty()) this.usrId = userId
 

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/InstallerService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/InstallerService.kt
@@ -4,4 +4,6 @@ import io.reactivex.Single
 
 interface InstallerService {
   fun getInstallerPackageName(appPackageName: String): Single<String>
+
+  fun isPackageInstalled(appPackageName: String): Boolean
 }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/InstallerSourceService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/InstallerSourceService.kt
@@ -1,6 +1,7 @@
 package com.appcoins.wallet.core.analytics.analytics.partners
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Single
@@ -20,6 +21,15 @@ class InstallerSourceService @Inject constructor(@ApplicationContext val context
       return Single.just(context.packageManager.getInstallerPackageName(appPackageName) ?: "")
     } catch (e: IllegalArgumentException) {
       return Single.just("")
+    }
+  }
+
+  override fun isPackageInstalled(appPackageName: String): Boolean {
+    return try {
+      context.packageManager.getPackageInfo(appPackageName, 0)
+      true
+    } catch (e: PackageManager.NameNotFoundException) {
+      false
     }
   }
 }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
@@ -114,7 +114,6 @@ class PartnerAddressService @Inject constructor(
         Single.just(GH_NOT_INSTALLED)
       }
     } else {
-      oemIdPreferencesDataSource.setGamesHubOemIdIndicative(ghOemIdIndicative)
       Single.just(ghOemIdIndicative)
     }
   }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
@@ -109,10 +109,12 @@ class PartnerAddressService @Inject constructor(
           oemIdPreferencesDataSource.setGamesHubOemIdIndicative(it)
         }
       } else {
+        oemIdPreferencesDataSource.setGamesHubOemIdIndicative(GH_NOT_INSTALLED)
         //If Games hub not installed return this text
         Single.just(GH_NOT_INSTALLED)
       }
     } else {
+      oemIdPreferencesDataSource.setGamesHubOemIdIndicative(ghOemIdIndicative)
       Single.just(ghOemIdIndicative)
     }
   }
@@ -120,10 +122,8 @@ class PartnerAddressService @Inject constructor(
   private fun getOemIdFromGamesHub(): Single<String> {
    return oemIdExtractorService.extractOemId(defaultGamesHubPackage)
       .map { gamesHubOemId ->
-        if (gamesHubOemId.isEmpty()) {
+        gamesHubOemId.ifEmpty {
           GH_INSTALLED_WITHOUT_OEMID
-        } else {
-          gamesHubOemId
         }
       }
   }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
@@ -110,7 +110,7 @@ class PartnerAddressService @Inject constructor(
         }
       } else {
         //If Games hub not installed return this text
-        Single.just(GAMES_HUB_UNINSTALLED)
+        Single.just(GH_NOT_INSTALLED)
       }
     } else {
       Single.just(ghOemIdIndicative)
@@ -121,7 +121,7 @@ class PartnerAddressService @Inject constructor(
    return oemIdExtractorService.extractOemId(defaultGamesHubPackage)
       .map { gamesHubOemId ->
         if (gamesHubOemId.isEmpty()) {
-          MISSING_OEMID_FROM_GAMES_HUB
+          GH_INSTALLED_WITHOUT_OEMID
         } else {
           gamesHubOemId
         }
@@ -137,8 +137,8 @@ class PartnerAddressService @Inject constructor(
     private const val DEFAULT_STORE_ADDRESS = "0xc41b4160b63d1f9488937f7b66640d2babdbf8ad"
     private const val DEFAULT_OEM_ADDRESS = "DEFAULT_OEM_ADDRESS"
     private const val MAX_AGE_CLIENT_SIDE_PACKAGE_LIST = 7 * 24 * 60 * 60 * 1000L // 1 week
-    private const val MISSING_OEMID_FROM_GAMES_HUB = "Games Hub installed but does not have oemID"
-    private const val GAMES_HUB_UNINSTALLED = "Games Hub not installed"
+    private const val GH_INSTALLED_WITHOUT_OEMID = "gh_installed_without_oemid"
+    private const val GH_NOT_INSTALLED = "gh_not_installed"
   }
 
 }

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/partners/PartnerAddressService.kt
@@ -106,7 +106,7 @@ class PartnerAddressService @Inject constructor(
       if (installerService.isPackageInstalled(defaultGamesHubPackage)) {
         //Try to extract OemID if Games Hun installed
         getOemIdFromGamesHub().doOnSuccess {
-          oemIdPreferencesDataSource.setCurrentOemId(it)
+          oemIdPreferencesDataSource.setGamesHubOemIdIndicative(it)
         }
       } else {
         //If Games hub not installed return this text

--- a/core/shared-preferences/src/main/java/com/appcoins/wallet/sharedpreferences/OemIdPreferencesDataSource.kt
+++ b/core/shared-preferences/src/main/java/com/appcoins/wallet/sharedpreferences/OemIdPreferencesDataSource.kt
@@ -18,8 +18,13 @@ class OemIdPreferencesDataSource @Inject constructor(
       .putString(CURRENT_OEMID, value)
       .apply()
 
-  fun getCurrentOemId() = sharedPreferences.getString(CURRENT_OEMID, "") ?: ""
+  fun getGamesHubOemIdIndicative() = sharedPreferences.getString(GAMES_HUB_INSTALLED_OEMID, "") ?: ""
+  fun setGamesHubOemIdIndicative(value: String?) =
+    sharedPreferences.edit()
+      .putString(GAMES_HUB_INSTALLED_OEMID, value)
+      .apply()
 
+  fun getCurrentOemId() = sharedPreferences.getString(CURRENT_OEMID, "") ?: ""
   fun setIsGameFromGameshub(value: Boolean) =
     sharedPreferences.edit()
       .putBoolean(IS_GAME_FROM_GAMESHUB_KEY, value)
@@ -57,5 +62,6 @@ class OemIdPreferencesDataSource @Inject constructor(
     private const val CLIENT_SIDE_CACHED_OEMID = "client_side_cached_oemid"
     private const val PACKAGES_CLIENT_SIDE = "packages_client_side"
     private const val LAST_TIMESTAMP_PACKAGES = "last_timestamp_packages"
+    private const val GAMES_HUB_INSTALLED_OEMID = "games_hub"
   }
 }


### PR DESCRIPTION
**What does this PR do?**

  include super properties inside Analytics to send in every analytics if user have GH installed and correct OEMID

**Database changed?**

   No

**How should this be manually tested?**

 Clean the wallet cache and open wallet with GH install or not and see the analytics parameter gh_oemid

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4095](https://aptoide.atlassian.net/browse/APPC-4095)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4095]: https://aptoide.atlassian.net/browse/APPC-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ