### PR TITLE
[APPC-4009]Add language to payment methods api

### DIFF
--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/BrokerBdsApi.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/BrokerBdsApi.kt
@@ -45,7 +45,8 @@ interface BrokerBdsApi {
     @Query("domain") packageName: String?,
     @Query("dark_theme") darkTheme: Boolean = false,
     @Query("oem_id") entityOemId: String?,
-    @Query("wallet.address") walletAddress: String?
+    @Query("wallet.address") walletAddress: String?,
+    @Header("Accept-Language") language: String,
   ): Single<GetMethodsResponse>
 
   @FormUrlEncoded

--- a/legacy/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
+++ b/legacy/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
@@ -279,7 +279,8 @@ class RemoteRepository(
       packageName = packageName,
       darkTheme = transactionType == TOP_UP_TYPE,
       entityOemId = entityOemId,
-      walletAddress = address
+      walletAddress = address,
+      language = Locale.getDefault().language,
     )
       .map { responseMapper.map(it) }
 


### PR DESCRIPTION
**What does this PR do?**
   Add Header on /methods api to return payment methods with selected language

**Database changed?**

 No

**How should this be manually tested?**

  try to make a payment and verify if the language of the payment methods is the same of the device, doesn’t try it with english, because it is the default.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4009](https://aptoide.atlassian.net/browse/APPC-4009)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4009]: https://aptoide.atlassian.net/browse/APPC-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ