### PR TITLE
[APPC-4076] Fix preselection of payment methods in Russia

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsAdapter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsAdapter.kt
@@ -20,7 +20,7 @@ class PaymentMethodsAdapter(
   private val showPayPalLogout: Subject<Boolean>
 ) :
   RecyclerView.Adapter<PaymentMethodsViewHolder>() {
-  private var selectedItem = -1
+  private var selectedItem = 0
 
   init {
     paymentMethods.forEachIndexed { index, paymentMethod ->


### PR DESCRIPTION
**What does this PR do?**

  When in Russia (VPN), no one payment method is preselected

**Database changed?**

 No

**How should this be manually tested?**

  Change VPN to Russia and make a payment, it should have the first payment method selected

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4076](https://aptoide.atlassian.net/browse/APPC-4076)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4076]: https://aptoide.atlassian.net/browse/APPC-4076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ