### PR TITLE
[APPC-4039] Fix plurals strings on Countdown Timer

### DIFF
--- a/ui/common/src/main/res/values-ar/strings.xml
+++ b/ui/common/src/main/res/values-ar/strings.xml
@@ -1238,7 +1238,7 @@
   <string name="topup_home_button">أعد تعبئة</string>
   <string name="intro_home_button">الرئيسية</string>
   <string name="intro_rewards_button">الجوائز</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="zero">يوم</item>
     <item quantity="one">يوم</item>
     <item quantity="two">يومان</item>
@@ -1246,7 +1246,7 @@
     <item quantity="many">يوم</item>
     <item quantity="other">يوم</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="zero">ساعة</item>
     <item quantity="one">ساعة</item>
     <item quantity="two">ساعتان</item>
@@ -1254,7 +1254,7 @@
     <item quantity="many">ساعة</item>
     <item quantity="other">ساعة</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="zero">دقيقة</item>
     <item quantity="one">دقيقة</item>
     <item quantity="two">دقيقتان</item>
@@ -1262,7 +1262,7 @@
     <item quantity="many">دقيقة</item>
     <item quantity="other">دقيقة</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="zero">ثانية</item>
     <item quantity="one">ثانية</item>
     <item quantity="two">ثانيتان</item>

--- a/ui/common/src/main/res/values-bn/strings.xml
+++ b/ui/common/src/main/res/values-bn/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Top Up</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Rewards</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAY</item>
     <item quantity="other">DAYS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HOUR</item>
     <item quantity="other">HOURS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECOND</item>
     <item quantity="other">SECONDS</item>
   </plurals>

--- a/ui/common/src/main/res/values-de/strings.xml
+++ b/ui/common/src/main/res/values-de/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Aufladen</string>
   <string name="intro_home_button">Startseite</string>
   <string name="intro_rewards_button">Belohnungen</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">TAG</item>
     <item quantity="other">TAGE</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">STUNDE</item>
     <item quantity="other">STUNDEN</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">MINUTEN</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEKUNDE</item>
     <item quantity="other">SEKUNDEN</item>
   </plurals>

--- a/ui/common/src/main/res/values-el/strings.xml
+++ b/ui/common/src/main/res/values-el/strings.xml
@@ -1202,19 +1202,19 @@ Wallets</item>
   <string name="topup_home_button">Φόρτιση</string>
   <string name="intro_home_button">Σπίτι</string>
   <string name="intro_rewards_button">Ανταμοιβές</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">ΜΕΡΑ</item>
     <item quantity="other">ΜΕΡΕΣ</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ΩΡΑ</item>
     <item quantity="other">ΩΡΕΣ</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">ΛΕΠΤΟ</item>
     <item quantity="other">ΛΕΠΤΑ</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">ΔΕΥΤΕΡΟΛΕΠΤΟ</item>
     <item quantity="other">ΔΕΥΤΕΡΟΛΕΠΤΑ</item>
   </plurals>

--- a/ui/common/src/main/res/values-es/strings.xml
+++ b/ui/common/src/main/res/values-es/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Recargar</string>
   <string name="intro_home_button">Inicio</string>
   <string name="intro_rewards_button">Recompensas</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DÍA</item>
     <item quantity="other">DÍAS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HORA</item>
     <item quantity="other">HORAS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTO</item>
     <item quantity="other">MINUTOS</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEGUNDO</item>
     <item quantity="other">SEGUNDOS</item>
   </plurals>

--- a/ui/common/src/main/res/values-fa/strings.xml
+++ b/ui/common/src/main/res/values-fa/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">افزایش اعتبار</string>
   <string name="intro_home_button">خانه</string>
   <string name="intro_rewards_button">پاداش‌ها</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">روز</item>
     <item quantity="other">روز</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ساعت</item>
     <item quantity="other">ساعت</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">دقیقه</item>
     <item quantity="other">دقیقه</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">ثانیه</item>
     <item quantity="other">ثانیه</item>
   </plurals>

--- a/ui/common/src/main/res/values-fr/strings.xml
+++ b/ui/common/src/main/res/values-fr/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Recharger</string>
   <string name="intro_home_button">Accueil</string>
   <string name="intro_rewards_button">Récompenses</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">JOUR</item>
     <item quantity="other">JOURS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HEURE</item>
     <item quantity="other">HEURES</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECONDE</item>
     <item quantity="other">SECONDES</item>
   </plurals>

--- a/ui/common/src/main/res/values-hi/strings.xml
+++ b/ui/common/src/main/res/values-hi/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">टॉप अप</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Rewards</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAY</item>
     <item quantity="other">DAYS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HOUR</item>
     <item quantity="other">HOURS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECOND</item>
     <item quantity="other">SECONDS</item>
   </plurals>

--- a/ui/common/src/main/res/values-hu/strings.xml
+++ b/ui/common/src/main/res/values-hu/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Befizetés</string>
   <string name="intro_home_button">Kezdőlap</string>
   <string name="intro_rewards_button">Jutalmak</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">NAP</item>
     <item quantity="other">NAPOK</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ÓRA</item>
     <item quantity="other">ÓRÁK</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">PERC</item>
     <item quantity="other">PERCEK</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">MÁSODPERC</item>
     <item quantity="other">MÁSODPERCEK</item>
   </plurals>

--- a/ui/common/src/main/res/values-in/strings.xml
+++ b/ui/common/src/main/res/values-in/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">Isi Ulang</string>
   <string name="intro_home_button">Beranda</string>
   <string name="intro_rewards_button">Hadiah</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">HARI</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">JAM</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">MENIT</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">DETIK</item>
   </plurals>
   <string name="intro_transactions_header">Transaksi</string>

--- a/ui/common/src/main/res/values-it/strings.xml
+++ b/ui/common/src/main/res/values-it/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Ricarica</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Premi</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">GIORNO</item>
     <item quantity="other">GIORNI</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ORA</item>
     <item quantity="other">ORE</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTO</item>
     <item quantity="other">MINUTI</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECONDO</item>
     <item quantity="other">SECONDI</item>
   </plurals>

--- a/ui/common/src/main/res/values-ja/strings.xml
+++ b/ui/common/src/main/res/values-ja/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">トップアップします。</string>
   <string name="intro_home_button">ホーム</string>
   <string name="intro_rewards_button">リワード</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">日</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">時間</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">分</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">秒</item>
   </plurals>
   <string name="intro_transactions_header">取引</string>

--- a/ui/common/src/main/res/values-ko/strings.xml
+++ b/ui/common/src/main/res/values-ko/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">충전</string>
   <string name="intro_home_button">홈</string>
   <string name="intro_rewards_button">보상</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">일</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">시간</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">분</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">초</item>
   </plurals>
   <string name="intro_transactions_header">거래</string>

--- a/ui/common/src/main/res/values-mr/strings.xml
+++ b/ui/common/src/main/res/values-mr/strings.xml
@@ -1222,19 +1222,19 @@
   <string name="topup_home_button">भरणा करा</string>
   <string name="intro_home_button">मुख्य पृष्ठ</string>
   <string name="intro_rewards_button">बक्षिसे</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAY</item>
     <item quantity="other">दिवस</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">दिवस</item>
     <item quantity="other">तास</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">मिनिटे</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECOND</item>
     <item quantity="other">सेकंद</item>
   </plurals>

--- a/ui/common/src/main/res/values-ms/strings.xml
+++ b/ui/common/src/main/res/values-ms/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">Tambah Nilai</string>
   <string name="intro_home_button">Utama</string>
   <string name="intro_rewards_button">Ganjaran</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">HARI</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">JAM</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">MINIT</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">SAAT</item>
   </plurals>
   <string name="intro_transactions_header">Transaksi</string>

--- a/ui/common/src/main/res/values-my/strings.xml
+++ b/ui/common/src/main/res/values-my/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">ေငြျဖည့္မည္</string>
   <string name="intro_home_button">ပင္မ</string>
   <string name="intro_rewards_button">ဆုမ်ား</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">ေန႔</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">နာရီ</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">မိနစ္</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">စကၠန႔္</item>
   </plurals>
   <string name="intro_transactions_header">ေငြလႊဲေျပာင္းမႈမ်ား</string>

--- a/ui/common/src/main/res/values-nl/strings.xml
+++ b/ui/common/src/main/res/values-nl/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Opwaarderen</string>
   <string name="intro_home_button">Start</string>
   <string name="intro_rewards_button">Beloningen</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAG</item>
     <item quantity="other">DAGEN</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">UUR</item>
     <item quantity="other">UUR</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUUT</item>
     <item quantity="other">MINUTEN</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECONDE</item>
     <item quantity="other">SECONDEN</item>
   </plurals>

--- a/ui/common/src/main/res/values-pa/strings.xml
+++ b/ui/common/src/main/res/values-pa/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">ਟੋਪ ਅੱਪ</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Rewards</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAY</item>
     <item quantity="other">DAYS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HOUR</item>
     <item quantity="other">HOURS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTE</item>
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECOND</item>
     <item quantity="other">SECONDS</item>
   </plurals>

--- a/ui/common/src/main/res/values-pl/strings.xml
+++ b/ui/common/src/main/res/values-pl/strings.xml
@@ -1219,25 +1219,25 @@
   <string name="topup_home_button">Doładuj</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Nagrody</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">Dzień</item>
     <item quantity="few">Dni</item>
     <item quantity="many">Dni</item>
     <item quantity="other">Dni</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">GODZINA</item>
     <item quantity="few">GODZIN</item>
     <item quantity="many">GODZINY</item>
     <item quantity="other">GODZIN</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTA</item>
     <item quantity="few">MINUTY</item>
     <item quantity="many">MINUT</item>
     <item quantity="other">MINUT</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEKUNDA</item>
     <item quantity="few">SEKUNDY</item>
     <item quantity="many">SEKUND</item>

--- a/ui/common/src/main/res/values-pt-rBR/strings.xml
+++ b/ui/common/src/main/res/values-pt-rBR/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Depositar</string>
   <string name="intro_home_button">Início</string>
   <string name="intro_rewards_button">Recompensas</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DIA</item>
     <item quantity="other">DIAS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HORA</item>
     <item quantity="other">HORAS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTO</item>
     <item quantity="other">MINUTOS</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEGUNDO</item>
     <item quantity="other">SEGUNDOS</item>
   </plurals>

--- a/ui/common/src/main/res/values-pt/strings.xml
+++ b/ui/common/src/main/res/values-pt/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Carregar</string>
   <string name="intro_home_button">Início</string>
   <string name="intro_rewards_button">Recompensas</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DIA</item>
     <item quantity="other">DIAS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">HORA</item>
     <item quantity="other">HORAS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUTO</item>
     <item quantity="other">MINUTOS</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEGUNDO</item>
     <item quantity="other">SEGUNDOS</item>
   </plurals>

--- a/ui/common/src/main/res/values-ro/strings.xml
+++ b/ui/common/src/main/res/values-ro/strings.xml
@@ -1210,22 +1210,22 @@
   <string name="topup_home_button">Alimentează</string>
   <string name="intro_home_button">Acasă</string>
   <string name="intro_rewards_button">Recompense</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">ZI</item>
     <item quantity="few">ZILE</item>
     <item quantity="other">ZILE</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ORĂ</item>
     <item quantity="few">ORE</item>
     <item quantity="other">ORE</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUT</item>
     <item quantity="few">MINUTE</item>
     <item quantity="other">MINUTE</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SECUNDĂ</item>
     <item quantity="few">SECUNDE</item>
     <item quantity="other">SECUNDE</item>

--- a/ui/common/src/main/res/values-ru/strings.xml
+++ b/ui/common/src/main/res/values-ru/strings.xml
@@ -1219,25 +1219,25 @@
   <string name="topup_home_button">Пополнить</string>
   <string name="intro_home_button">Главная</string>
   <string name="intro_rewards_button">Награды</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">ДЕНЬ</item>
     <item quantity="few">ДНЯ</item>
     <item quantity="many">ДНЕЙ</item>
     <item quantity="other">ДНЕЙ</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ЧАС</item>
     <item quantity="few">ЧАСА</item>
     <item quantity="many">ЧАСОВ</item>
     <item quantity="other">ЧАСОВ</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">МИНУТА</item>
     <item quantity="few">МИНУТЫ</item>
     <item quantity="many">МИНУТ</item>
     <item quantity="other">МИНУТ</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">СЕКУНДА</item>
     <item quantity="few">СЕКУНДЫ</item>
     <item quantity="many">СЕКУНД</item>

--- a/ui/common/src/main/res/values-sr/strings.xml
+++ b/ui/common/src/main/res/values-sr/strings.xml
@@ -1210,22 +1210,22 @@
   <string name="topup_home_button">Dopunite</string>
   <string name="intro_home_button">Početna stranica</string>
   <string name="intro_rewards_button">Nagrade</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">DAN</item>
     <item quantity="few">DANA</item>
     <item quantity="other">DANA</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">SAT</item>
     <item quantity="few">SATA</item>
     <item quantity="other">SATI</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">MINUT</item>
     <item quantity="few">MINUTA</item>
     <item quantity="other">MINUTA</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SEKUNDA</item>
     <item quantity="few">SEKUNDE</item>
     <item quantity="other">SEKUNDI</item>

--- a/ui/common/src/main/res/values-th/strings.xml
+++ b/ui/common/src/main/res/values-th/strings.xml
@@ -1194,16 +1194,16 @@
   <string name="topup_home_button">เติม</string>
   <string name="intro_home_button">หน้าแรก</string>
   <string name="intro_rewards_button">รางวัล</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">วัน</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">ชั่วโมง</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">นาที</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">วินาที</item>
   </plurals>
   <string name="intro_transactions_header">ธุรกรรม</string>

--- a/ui/common/src/main/res/values-tr/strings.xml
+++ b/ui/common/src/main/res/values-tr/strings.xml
@@ -1201,19 +1201,19 @@
   <string name="topup_home_button">Yükle</string>
   <string name="intro_home_button">Ana Sayfa</string>
   <string name="intro_rewards_button">Ödüller</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">GÜN</item>
     <item quantity="other">GÜN</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">SAAT</item>
     <item quantity="other">SAAT</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">DAKİKA</item>
     <item quantity="other">DAKİKA</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">SANİYE</item>
     <item quantity="other">SANİYE</item>
   </plurals>

--- a/ui/common/src/main/res/values-uk/strings.xml
+++ b/ui/common/src/main/res/values-uk/strings.xml
@@ -1221,25 +1221,25 @@
   <string name="topup_home_button">Поповнити</string>
   <string name="intro_home_button">На домашню</string>
   <string name="intro_rewards_button">Винагороди</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="one">ДЕНЬ</item>
     <item quantity="few">ДНІВ</item>
     <item quantity="many">ДНІВ</item>
     <item quantity="other">ДНІ</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="one">ГОДИНА</item>
     <item quantity="few">ГОДИН</item>
     <item quantity="many">ГОДИН</item>
     <item quantity="other">ГОДИНИ</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="one">ХВИЛИНА</item>
     <item quantity="few">ХВИЛИН</item>
     <item quantity="many">ХВИЛИН</item>
     <item quantity="other">ХВИЛИНИ</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="one">СЕКУНДА</item>
     <item quantity="few">СЕКУНД</item>
     <item quantity="many">СЕКУНД</item>

--- a/ui/common/src/main/res/values-vi/strings.xml
+++ b/ui/common/src/main/res/values-vi/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">Nạp tiền</string>
   <string name="intro_home_button">Trang chủ</string>
   <string name="intro_rewards_button">Phần thưởng</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">NGÀY</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">GIỜ</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">PHÚT</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">GIÂY</item>
   </plurals>
   <string name="intro_transactions_header">Giao dịch</string>

--- a/ui/common/src/main/res/values-zh-rCN/strings.xml
+++ b/ui/common/src/main/res/values-zh-rCN/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">充值</string>
   <string name="intro_home_button">主页</string>
   <string name="intro_rewards_button">奖励</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">天</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">小时</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">分钟</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">秒</item>
   </plurals>
   <string name="intro_transactions_header">交易</string>

--- a/ui/common/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/common/src/main/res/values-zh-rTW/strings.xml
@@ -1192,16 +1192,16 @@
   <string name="topup_home_button">儲值</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Rewards</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="other">DAYS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="other">HOURS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="other">SECONDS</item>
   </plurals>
   <string name="intro_transactions_header">Transactions</string>

--- a/ui/common/src/main/res/values/strings.xml
+++ b/ui/common/src/main/res/values/strings.xml
@@ -1323,7 +1323,7 @@
   <string name="topup_home_button">Top Up</string>
   <string name="intro_home_button">Home</string>
   <string name="intro_rewards_button">Rewards</string>
-  <plurals name="days">
+  <plurals name="day">
     <item quantity="zero">DAYS</item>
     <item quantity="one">DAY</item>
     <item quantity="two">DAYS</item>
@@ -1331,7 +1331,7 @@
     <item quantity="many">DAYS</item>
     <item quantity="other">DAYS</item>
   </plurals>
-  <plurals name="hours">
+  <plurals name="hour">
     <item quantity="zero">HOURS</item>
     <item quantity="one">HOUR</item>
     <item quantity="two">HOURS</item>
@@ -1339,7 +1339,7 @@
     <item quantity="many">HOURS</item>
     <item quantity="other">HOURS</item>
   </plurals>
-  <plurals name="minutes">
+  <plurals name="minute">
     <item quantity="zero">MINUTES</item>
     <item quantity="one">MINUTE</item>
     <item quantity="two">MINUTES</item>
@@ -1347,7 +1347,7 @@
     <item quantity="many">MINUTES</item>
     <item quantity="other">MINUTES</item>
   </plurals>
-  <plurals name="seconds">
+  <plurals name="second">
     <item quantity="zero">SECONDS</item>
     <item quantity="one">SECOND</item>
     <item quantity="two">SECONDS</item>
@@ -1355,7 +1355,6 @@
     <item quantity="many">SECONDS</item>
     <item quantity="other">SECONDS</item>
   </plurals>
-
   <string name="intro_transactions_header">Transactions</string>
   <string name="intro_backup_card_title">Don\'t loose your funds!</string>
   <string name="intro_backup_card_body">Back up your wallet and keep it safe all times.</string>

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -209,28 +209,28 @@ fun CountDownTimer(endDateTime: Long) {
     CardWithTextAndDetail(
       text = remainingTime.value.toDays().toString(),
       detail = pluralStringResource(
-        id = R.plurals.days,
+        id = R.plurals.day,
         count = remainingTime.value.toDays().toInt()
       )
     )
     CardWithTextAndDetail(
       text = (remainingTime.value.toHours() % 24).toString(),
       detail = pluralStringResource(
-        id = R.plurals.hours,
+        id = R.plurals.hour,
         count = (remainingTime.value.toHours() % 24).toInt()
       )
     )
     CardWithTextAndDetail(
       text = (remainingTime.value.toMinutes() % 60).toString(),
       detail = pluralStringResource(
-        id = R.plurals.minutes,
+        id = R.plurals.minute,
         count = (remainingTime.value.toMinutes() % 60).toInt()
       )
     )
     CardWithTextAndDetail(
       text = (remainingTime.value.seconds % 60).toString(),
       detail = pluralStringResource(
-        id = R.plurals.seconds,
+        id = R.plurals.second,
         count = (remainingTime.value.seconds % 60).toInt()
       )
     )
@@ -377,7 +377,11 @@ private fun SkeletonLoadingPromotionCardItem(hasVerticalList: Boolean) {
     Modifier
       .fillMaxWidth()
       .width(maxColumnWidth)
-      .padding(top = 16.dp, start = if (hasVerticalList) 16.dp else 0.dp, end = if (hasVerticalList) 16.dp else 16.dp)
+      .padding(
+        top = 16.dp,
+        start = if (hasVerticalList) 16.dp else 0.dp,
+        end = 16.dp
+      )
       .clip(shape = RoundedCornerShape(8.dp))
   ) {
     Column( modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)) {


### PR DESCRIPTION
…ct with skills string

**What does this PR do?**

Fix conflict on strings plurals with skills

**Database changed?**

No

**How should this be manually tested?**

  verify if the strings on contdown on promotions on Home is working well

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4039](https://aptoide.atlassian.net/browse/APPC-4039)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4039]: https://aptoide.atlassian.net/browse/APPC-4039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ