### PR TITLE
[APPC-4091] Fix height bug on ActionCard Composable

### DIFF
--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
@@ -8,9 +8,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -45,7 +46,8 @@ fun RewardsActions(
     modifier = Modifier
       .horizontalScroll(scrollState)
       .padding(horizontal = 16.dp)
-      .padding(top = 24.dp),
+      .padding(top = 24.dp)
+      .height(IntrinsicSize.Max),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     onClickChallengeReward?.let {
@@ -86,7 +88,8 @@ fun ActionCard(
 ) {
   Card(
     modifier = Modifier
-      .size(width = 160.dp, height = 208.dp)
+      .width(width = 160.dp)
+      .fillMaxHeight()
       .clickable { onClick() },
     shape = RoundedCornerShape(8.dp),
     colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),


### PR DESCRIPTION
**What does this PR do?**

set dynamically the height of the action cards on rewards screen

**Database changed?**

No

**How should this be manually tested?**

  go to rewards screen and check if cards height is correct

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4091](https://aptoide.atlassian.net/browse/APPC-4091)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4091]: https://aptoide.atlassian.net/browse/APPC-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ