### PR TITLE
[APPC-3763] Fixed back press on first payment flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.Nullable
@@ -100,6 +101,9 @@ class OnboardingAdyenPaymentFragment : BasePageViewFragment(),
         shouldStoreCard(),
         RedirectComponent.getReturnUrl(requireContext())
       )
+    }
+    requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+      navigator.navigateBack()
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/adyen_payment/OnboardingAdyenPaymentNavigator.kt
@@ -9,6 +9,7 @@ import com.appcoins.wallet.billing.adyen.PaymentModel
 import com.appcoins.wallet.gamification.repository.ForecastBonusAndLevel
 import com.appcoins.wallet.core.arch.data.Navigator
 import com.appcoins.wallet.core.arch.data.navigate
+import com.asf.wallet.R
 import com.asfoundation.wallet.billing.adyen.PaymentType
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.ui.iab.WebViewActivity
@@ -18,7 +19,8 @@ class OnboardingAdyenPaymentNavigator @Inject constructor(private val fragment: 
   Navigator {
 
   fun navigateBack() {
-    fragment.findNavController().popBackStack()
+    fragment.findNavController()
+      .popBackStack(R.id.onboarding_payment_methods_fragment, inclusive = false)
   }
 
   fun navigateToWebView(url: String, webViewLauncher: ActivityResultLauncher<Intent>) {

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/local_payments/OnboardingLocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/local_payments/OnboardingLocalPaymentFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.Nullable
@@ -103,6 +104,9 @@ class OnboardingLocalPaymentFragment : BasePageViewFragment(),
     private fun clickListeners() {
         binding.errorView.errorDismiss.setOnClickListener {
             viewModel.handleBackButton()
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navigator.navigateBack()
         }
     }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/local_payments/OnboardingLocalPaymentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/local_payments/OnboardingLocalPaymentNavigator.kt
@@ -20,7 +20,8 @@ class OnboardingLocalPaymentNavigator @Inject constructor(
     Navigator {
 
     fun navigateBack() {
-        fragment.findNavController().popBackStack()
+        fragment.findNavController()
+            .popBackStack(R.id.onboarding_payment_methods_fragment, inclusive = false)
     }
 
     fun navigateToWebView(url: String, webViewLauncher: ActivityResultLauncher<Intent>) {

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/vkPayment/OnboardingVkPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/vkPayment/OnboardingVkPaymentFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.annotation.Nullable
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -112,6 +113,9 @@ class OnboardingVkPaymentFragment : BasePageViewFragment(),
     }
     binding.onboardingSuccessVkButtons.exploreWalletButton.setOnClickListener {
       viewModel.handleExploreWalletClick()
+    }
+    requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+      navigator.navigateBack()
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/vkPayment/OnboardingVkPaymentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/vkPayment/OnboardingVkPaymentNavigator.kt
@@ -11,6 +11,7 @@ import com.appcoins.wallet.billing.adyen.PaymentModel
 import com.appcoins.wallet.core.arch.data.Navigator
 import com.appcoins.wallet.core.arch.data.navigate
 import com.appcoins.wallet.gamification.repository.ForecastBonusAndLevel
+import com.asf.wallet.R
 import com.asfoundation.wallet.billing.adyen.PaymentType
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.onboarding.pending_payment.OnboardingPaymentFragment
@@ -23,7 +24,8 @@ class OnboardingVkPaymentNavigator @Inject constructor(
   Navigator {
 
   fun navigateBack() {
-    fragment.findNavController().popBackStack()
+    fragment.findNavController()
+      .popBackStack(R.id.onboarding_payment_methods_fragment, inclusive = false)
   }
 
   /**


### PR DESCRIPTION
**What does this PR do?**

 Fixed the back press on fragment after  first payment methods list to back from payment methods Lists

**Database changed?**

   No


**How should this be manually tested?**

  Try to make a frist payment and after select credit card press back button

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-3763](https://aptoide.atlassian.net/browse/APPC-3763)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
