### PR TITLE
[APPC-4304]HotFix first payment analytics after recover from web

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingViewModel.kt
@@ -12,12 +12,12 @@ import com.appcoins.wallet.core.utils.android_common.RxSchedulers
 import com.appcoins.wallet.feature.changecurrency.data.currencies.FiatValue
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.UpdateWalletInfoUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.UpdateWalletNameUseCase
+import com.asfoundation.wallet.analytics.SaveIsFirstPaymentUseCase
 import com.asfoundation.wallet.app_start.AppStartUseCase
 import com.asfoundation.wallet.app_start.StartMode
 import com.asfoundation.wallet.entity.WalletKeyStore
 import com.asfoundation.wallet.main.use_cases.DeleteCachedGuestWalletUseCase
 import com.asfoundation.wallet.main.use_cases.GetBonusGuestWalletUseCase
-import com.asfoundation.wallet.my_wallets.create_wallet.CreateWalletUseCase
 import com.asfoundation.wallet.onboarding.use_cases.HasWalletUseCase
 import com.asfoundation.wallet.onboarding.use_cases.SetOnboardingCompletedUseCase
 import com.asfoundation.wallet.recover.result.FailedEntryRecover
@@ -25,7 +25,6 @@ import com.asfoundation.wallet.recover.result.RecoverEntryResult
 import com.asfoundation.wallet.recover.result.SuccessfulEntryRecover
 import com.asfoundation.wallet.recover.use_cases.RecoverEntryPrivateKeyUseCase
 import com.asfoundation.wallet.recover.use_cases.SetDefaultWalletUseCase
-import com.asfoundation.wallet.recover.use_cases.UpdateBackupStateFromRecoverUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.Completable
 import io.reactivex.Single
@@ -52,16 +51,15 @@ class OnboardingViewModel @Inject constructor(
   private val hasWalletUseCase: HasWalletUseCase,
   private val rxSchedulers: RxSchedulers,
   private val setOnboardingCompletedUseCase: SetOnboardingCompletedUseCase,
-  private val createWalletUseCase: CreateWalletUseCase,
   private val recoverEntryPrivateKeyUseCase: RecoverEntryPrivateKeyUseCase,
   private val setDefaultWalletUseCase: SetDefaultWalletUseCase,
   private val updateWalletInfoUseCase: UpdateWalletInfoUseCase,
   private val updateWalletNameUseCase: UpdateWalletNameUseCase,
-  private val updateBackupStateFromRecoverUseCase: UpdateBackupStateFromRecoverUseCase,
   private val getBonusGuestWalletUseCase: GetBonusGuestWalletUseCase,
   private val deleteCachedGuestWalletUseCase: DeleteCachedGuestWalletUseCase,
   private val walletsEventSender: WalletsEventSender,
   private val onboardingAnalytics: OnboardingAnalytics,
+  private val saveIsFirstPaymentUseCase: SaveIsFirstPaymentUseCase,
   appStartUseCase: AppStartUseCase
 ) :
   BaseViewModel<OnboardingState, OnboardingSideEffect>(initialState()) {
@@ -150,6 +148,7 @@ class OnboardingViewModel @Inject constructor(
           WalletsAnalytics.STATUS_SUCCESS
         )
         deleteCachedGuest()
+        saveIsFirstPaymentUseCase(isFirstPayment = false)
         onboardingAnalytics.sendRecoverGuestWalletEvent(
           guestBonus.amount.toString(),
           guestBonus.currency
@@ -167,10 +166,6 @@ class OnboardingViewModel @Inject constructor(
         )
       }
     }
-
-  private fun updateWalletBackupState() {
-    updateBackupStateFromRecoverUseCase().scopedSubscribe()
-  }
 
   fun getGuestWalletBonus(key: String) {
     getBonusGuestWalletUseCase(key)


### PR DESCRIPTION
**What does this PR do?**

   Fix first payment analytics after recover from web to log regular.

**Database changed?**

 No

**How should this be manually tested?**

 after recover a wallet from first payment in web, verify indicative to validate if regular is on tags

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4304](https://aptoide.atlassian.net/browse/APPC-4304)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4304]: https://aptoide.atlassian.net/browse/APPC-4304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ