### PR TITLE
[Hotfix][APPC-2428] Fix overlapping error screens on verify

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/verification/ui/credit_card/code/VerificationCodePresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/verification/ui/credit_card/code/VerificationCodePresenter.kt
@@ -144,6 +144,8 @@ class VerificationCodePresenter(
     if (codeResult.success && !codeResult.error.hasError) {
       view.showSuccess()
       view.unlockRotation()
+    } else if (codeResult.error.isNetworkError) {
+      view.showNetworkError()
     } else {
       when (codeResult.errorType) {
         VerificationCodeResult.ErrorType.WRONG_CODE -> view.showWrongCodeError()

--- a/app/src/main/res/layout/fragment_verification_code.xml
+++ b/app/src/main/res/layout/fragment_verification_code.xml
@@ -183,7 +183,7 @@
       android:id="@+id/no_network"
       layout="@layout/no_network_retry_only_layout"
       android:layout_width="0dp"
-      android:layout_height="0dp"
+      android:layout_height="wrap_content"
       android:visibility="gone"
       app:layout_constraintBottom_toBottomOf="@id/half_guideline"
       app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
**What does this PR do?**

   This PR fix a overlapping of screens on verification with credit card, as described on Jira.

**Database changed?**

   No

**How should this be manually tested?**

 Start the verify flow, insert the valid dev card, turn off the wifi on the insert code screen, insert a wrong code, then tap on continue, on this step should appear no network error instead of the old problem.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2428](https://aptoide.atlassian.net/browse/APPC-2428)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-2428]: https://aptoide.atlassian.net/browse/APPC-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ