### PR TITLE
[APPC-4169] Iap paypal logout button in dark mode

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
@@ -9,7 +9,6 @@ import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.Pair
-import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -376,9 +375,7 @@ class PaymentMethodsFragment : BasePageViewFragment(), PaymentMethodsView {
       PaymentMethodId.PAYPAL_V2.id -> {
         binding.layoutPreSelected.paymentMoreLogout.visibility = View.VISIBLE
         binding.layoutPreSelected.paymentMoreLogout.setOnClickListener {
-          val wrapper: Context =
-            ContextThemeWrapper(context?.applicationContext, R.style.CustomLogoutPopUpStyle)
-          val popup = PopupMenu(wrapper, it)
+          val popup = PopupMenu(context?.applicationContext, it)
           popup.menuInflater.inflate(R.menu.logout_menu, popup.menu)
           popup.setOnMenuItemClickListener { menuItem: MenuItem ->
             binding.layoutPreSelected.paymentMoreLogout.visibility = View.GONE


### PR DESCRIPTION
**What does this PR do?**

   This PR changes the Iap paypal logout button from dark mode to light mode.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PaymentMethodsFragment.kt

**How should this be manually tested?**

  Make a payment with paypal to have the pre-selected paypal. On the paypal screen, select the paypal menu button to show the logout button. check if its in light mode instead of dark mode.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4169](https://aptoide.atlassian.net/browse/APPC-4169)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4169]: https://aptoide.atlassian.net/browse/APPC-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ