### PR TITLE
[APPC-4173] Top up space for bonus is empty in payment methods that don't give bonuses

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -493,7 +493,8 @@ class TopUpFragment : BasePageViewFragment(), TopUpFragmentView {
   }
 
   override fun hideBonus() {
-    binding.bonusLayout.root.visibility = View.INVISIBLE
+    binding.bonusLayout.root.visibility = View.GONE
+    binding.headerTopUpDivider.visibility = View.GONE
   }
 
   override fun hideBonusAndSkeletons() {
@@ -502,6 +503,7 @@ class TopUpFragment : BasePageViewFragment(), TopUpFragmentView {
   }
 
   override fun removeBonus() {
+    binding.headerTopUpDivider.visibility = View.GONE
     binding.bonusLayout.root.visibility = View.GONE
     binding.bonusLayoutSkeleton.root.visibility = View.GONE
   }
@@ -512,6 +514,7 @@ class TopUpFragment : BasePageViewFragment(), TopUpFragmentView {
   }
 
   override fun showBonus() {
+    binding.headerTopUpDivider.visibility = View.VISIBLE
     binding.bonusLayoutSkeleton.root.visibility = View.GONE
     binding.bonusLayout.root.visibility = View.VISIBLE
   }
@@ -586,6 +589,7 @@ class TopUpFragment : BasePageViewFragment(), TopUpFragmentView {
   }
 
   override fun showBonusSkeletons() {
+    binding.headerTopUpDivider.visibility = View.VISIBLE
     binding.bonusLayout.root.visibility = View.INVISIBLE
     binding.bonusLayoutSkeleton.root.visibility = View.VISIBLE
   }

--- a/app/src/main/res/layout-land/fragment_top_up.xml
+++ b/app/src/main/res/layout-land/fragment_top_up.xml
@@ -39,6 +39,7 @@
           android:layout_marginTop="16dp"
           android:background="@drawable/rectangle_blue_secondary_radius_16dp"
           android:visibility="visible"
+          android:animateLayoutChanges="true"
           app:layout_constraintEnd_toStartOf="@id/mid_guideline"
           app:layout_constraintHorizontal_bias="1.0"
           app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_top_up.xml
+++ b/app/src/main/res/layout/fragment_top_up.xml
@@ -29,6 +29,7 @@
           android:layout_marginTop="16dp"
           android:background="@drawable/rectangle_blue_secondary_radius_16dp"
           android:visibility="visible"
+          android:animateLayoutChanges="true"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintHorizontal_bias="1.0"
           app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
**What does this PR do?**

   Fixes the empty space for bonuses that don't have bonuses.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] fragment_top_up.xml
- [ ] land/fragment_top_up.xml
- [ ] TopUpFragment.kt

**How should this be manually tested?**

  Go to TopUp screen and check if the bonuses disappear or not depending if the payment method has bonuses or not.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4173](https://aptoide.atlassian.net/browse/APPC-4173)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4173]: https://aptoide.atlassian.net/browse/APPC-4173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ