### PR TITLE
[APPC-4445] Add navigation to promoCode screen from deeplink

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,10 +96,12 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <!-- Accepts URIs that begin with "example://gizmos” -->
-        <data android:scheme="appcoins"
-            android:host="${giftCardHost}" />
+
+        <data android:scheme="appcoins" />
+        <data android:host="${giftCardHost}" />
+        <data android:host="${promoCodeHost}" />
       </intent-filter>
+
     </activity>
     <activity
         android:name="com.asfoundation.wallet.ui.balance.TransactionDetailActivity"

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
@@ -107,6 +107,13 @@ class MainActivity : AppCompatActivity(),
             fromSplashScreen = fromSplashScreen
           )
 
+        BuildConfig.PROMO_CODE_HOST ->
+          viewModel.handleInitialNavigation(
+            authComplete = authComplete,
+            promoCode = intent.data?.getQueryParameter(DEEPLINK_PROMO_CODE_QUERY_PARAM),
+            fromSplashScreen = fromSplashScreen
+          )
+
         else ->
           viewModel.handleInitialNavigation(authComplete = authComplete)
       }
@@ -159,6 +166,22 @@ class MainActivity : AppCompatActivity(),
           }
         }
       }
+
+      is MainActivitySideEffect.NavigateToPromoCode -> if (navController.currentDestination?.id == R.id.nav_bar_fragment) {
+        setPromoCodeToCurrentFragment(sideEffect.promoCode)
+      } else {
+        if (sideEffect.fromSplashScreen) {
+          navigator.navigateToPromoCodeFromSplashScreen(
+            navController = navController,
+            promoCode = sideEffect.promoCode
+          )
+        } else {
+          navigator.navigateToPromoCode(
+            navController = navController,
+            promoCode = sideEffect.promoCode
+          )
+        }
+      }
     }
   }
 
@@ -168,6 +191,14 @@ class MainActivity : AppCompatActivity(),
       ?.fragments
       ?.last() as? NavBarFragment
     )?.handleGiftCard(giftCard)
+  }
+
+  private fun setPromoCodeToCurrentFragment(promoCode: String) {
+    (supportFragmentManager.findFragmentById(R.id.main_host_container)
+      ?.childFragmentManager
+      ?.fragments
+      ?.last() as? NavBarFragment
+    )?.handlePromoCode(promoCode)
   }
 
   override fun onDestroy() {
@@ -185,6 +216,7 @@ class MainActivity : AppCompatActivity(),
 
   companion object {
     private const val DEEPLINK_GIFT_CARD_QUERY_PARAM = "giftcard"
+    private const val DEEPLINK_PROMO_CODE_QUERY_PARAM = "promocode"
 
     fun newIntent(
       context: Context,

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivityNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivityNavigator.kt
@@ -70,4 +70,20 @@ class MainActivityNavigator @Inject constructor() :
       navOptions = NavOptions.Builder().setPopUpTo(R.id.nav_bar_fragment, true).build()
     )
   }
+
+  fun navigateToPromoCodeFromSplashScreen(navController: NavController, promoCode: String) {
+    navigate(
+      navController,
+      SplashExtenderFragmentDirections.actionNavigateToNavBarGraph(giftCard = null, promoCode = promoCode),
+    )
+  }
+
+  fun navigateToPromoCode(navController: NavController, promoCode: String) {
+    navigate(
+      navController = navController,
+      resId = R.id.navigate_to_nav_bar_fragment,
+      args = Bundle().apply { putString(NavBarFragment.EXTRA_PROMO_CODE, promoCode) },
+      navOptions = NavOptions.Builder().setPopUpTo(R.id.nav_bar_fragment, true).build()
+    )
+  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivityViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivityViewModel.kt
@@ -25,6 +25,7 @@ sealed class MainActivitySideEffect : SideEffect {
   object NavigateToFingerprintAuthentication : MainActivitySideEffect()
   object NavigateToPayPalVerification : MainActivitySideEffect()
   data class NavigateToGiftCard(val giftCard: String, val fromSplashScreen: Boolean) : MainActivitySideEffect()
+  data class NavigateToPromoCode(val promoCode: String, val fromSplashScreen: Boolean) : MainActivitySideEffect()
   data class NavigateToOnboardingRecoverGuestWallet(val backup: String, val flow: String) :
     MainActivitySideEffect()
 }
@@ -51,7 +52,7 @@ class MainActivityViewModel @Inject constructor(
     handleSavedStateParameters()
   }
 
-  fun handleInitialNavigation(authComplete: Boolean = false, giftCard: String? = null, fromSplashScreen: Boolean = false) {
+  fun handleInitialNavigation(authComplete: Boolean = false, giftCard: String? = null, promoCode: String? = null, fromSplashScreen: Boolean = false) {
     getAutoUpdateModelUseCase()
       .subscribeOn(rxSchedulers.io)
       .observeOn(rxSchedulers.main)
@@ -88,6 +89,9 @@ class MainActivityViewModel @Inject constructor(
 
           giftCard != null ->
             sendSideEffect { MainActivitySideEffect.NavigateToGiftCard(giftCard, fromSplashScreen) }
+
+          promoCode != null ->
+            sendSideEffect { MainActivitySideEffect.NavigateToPromoCode(promoCode, fromSplashScreen) }
 
           else ->
             sendSideEffect { MainActivitySideEffect.NavigateToNavigationBar }

--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
@@ -57,6 +57,7 @@ class NavBarFragment : BasePageViewFragment(), SingleStateFragment<NavBarState, 
 
   companion object {
     const val EXTRA_GIFT_CARD = "giftCard"
+    const val EXTRA_PROMO_CODE = "promoCode"
   }
 
   private lateinit var navHostFragment: NavHostFragment
@@ -97,11 +98,19 @@ class NavBarFragment : BasePageViewFragment(), SingleStateFragment<NavBarState, 
     arguments?.getString(EXTRA_GIFT_CARD)?.let {
       handleGiftCard(it)
     }
+    arguments?.getString(EXTRA_PROMO_CODE)?.let {
+      handlePromoCode(it)
+    }
   }
 
   fun handleGiftCard(giftCard: String) {
     viewModel.clickedItem.value = 1
     navigator.navigateToRewards(navHostFragment.navController, giftCard)
+  }
+
+  fun handlePromoCode(promoCode: String) {
+    viewModel.clickedItem.value = 1
+    navigator.navigateToRewards(navHostFragment.navController, promoCode = promoCode)
   }
 
   @Composable

--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragmentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragmentNavigator.kt
@@ -21,12 +21,23 @@ class NavBarFragmentNavigator @Inject constructor() : Navigator {
     )
   }
 
-  fun navigateToRewards(navController: NavController, giftCard: String? = null) {
+  fun navigateToRewards(navController: NavController, giftCard: String? = null, promoCode: String? = null) {
     navController.navigate(
       resId = R.id.reward_graph,
-      args = giftCard?.let { Bundle().apply { putString(RewardFragment.EXTRA_GIFT_CARD, giftCard) } },
+      args = getBundle(giftCard, promoCode),
       navOptions = NavOptions.Builder().apply { setPopUpTo(R.id.reward_fragment, true) }.build()
     )
+  }
+
+  private fun getBundle(giftCard: String?, promoCode: String?): Bundle? {
+    if (giftCard == null && promoCode == null) return null
+
+    return Bundle().apply {
+      when {
+        giftCard != null -> putString(RewardFragment.EXTRA_GIFT_CARD, giftCard)
+        else -> putString(RewardFragment.EXTRA_PROMO_CODE, promoCode)
+      }
+    }
   }
 
   fun showOnboardingGPInstallScreen(navController: NavController) {

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
@@ -47,6 +47,8 @@ class PromoCodeBottomSheetFragment :
   lateinit var rewardsAnalytics: RewardsAnalytics
 
   companion object {
+    private const val EXTRA_PROMO_CODE = "promoCode"
+
     @JvmStatic
     fun newInstance(): PromoCodeBottomSheetFragment {
       return PromoCodeBottomSheetFragment()
@@ -67,6 +69,7 @@ class PromoCodeBottomSheetFragment :
 
     setListeners()
     viewModel.collectStateAndEvents(lifecycle, viewLifecycleOwner.lifecycleScope)
+    viewModel.initialize(arguments?.getString(EXTRA_PROMO_CODE))
   }
 
   override fun onStart() {
@@ -87,7 +90,6 @@ class PromoCodeBottomSheetFragment :
     }
     views.promoCodeBottomSheetReplaceButton.setOnClickListener {
       rewardsAnalytics.replacePromoCodeImpressionEvent("")
-      viewModel.replaceClick()
     }
     views.promoCodeBottomSheetDeleteButton.setOnClickListener { viewModel.deleteClick() }
 
@@ -107,7 +109,11 @@ class PromoCodeBottomSheetFragment :
   override fun onStateChanged(state: PromoCodeBottomSheetState) {
     when (val clickAsync = state.submitPromoCodeAsync) {
       is Async.Uninitialized ->
-        initializePromoCode(state.storedPromoCodeAsync, state.shouldShowDefault)
+        initializePromoCode(
+          state.deeplinkPromoCode,
+          state.storedPromoCodeAsync,
+          state.shouldShowDefault
+        )
 
       is Async.Loading -> {
         if (clickAsync.value == null) {
@@ -138,10 +144,13 @@ class PromoCodeBottomSheetFragment :
   }
 
   fun initializePromoCode(
+    deeplinkPromoCode: Async<String>,
     storedPromoCodeAsync: Async<PromoCode>,
     shouldShowDefault: Boolean
   ) {
-    when (storedPromoCodeAsync) {
+    deeplinkPromoCode.value?.let {
+      views.promoCodeBottomSheetString.setText(it)
+    } ?: when (storedPromoCodeAsync) {
       is Async.Uninitialized,
       is Async.Loading -> {
         showDefaultScreen()
@@ -197,7 +206,6 @@ class PromoCodeBottomSheetFragment :
 
   private fun handleErrorState(promoCodeResult: PromoCodeResult?) {
     showDefaultScreen()
-    views.promoCodeBottomSheetSubmitButton.isEnabled = false
     when (promoCodeResult) {
       is FailedPromoCode.InvalidCode -> {
         views.promoCodeBottomSheetString.setError(getString(R.string.promo_code_view_error))
@@ -239,7 +247,8 @@ class PromoCodeBottomSheetFragment :
     views.promoCodeBottomSheetSubmitButton.visibility = View.VISIBLE
     views.promoCodeBottomSheetDeleteButton.visibility = View.GONE
     views.promoCodeBottomSheetReplaceButton.visibility = View.GONE
-    views.promoCodeBottomSheetSubmitButton.isEnabled = false
+    views.promoCodeBottomSheetSubmitButton.isEnabled =
+      views.promoCodeBottomSheetString.getText().isNotEmpty()
   }
 
   private fun showCurrentCodeScreen(promoCodeString: String) {

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
@@ -84,6 +84,7 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
 
   companion object {
     const val EXTRA_GIFT_CARD = "giftCard"
+    const val EXTRA_PROMO_CODE = "promoCode"
   }
 
   @Inject
@@ -118,6 +119,9 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
     viewModel.updateNotificationBadge()
     arguments?.getString(EXTRA_GIFT_CARD)?.let {
       navigator.showGiftCardFragment(it)
+    }
+    arguments?.getString(EXTRA_PROMO_CODE)?.let {
+      navigator.showPromoCodeFragment(it)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardNavigator.kt
@@ -22,8 +22,8 @@ constructor(private val fragment: Fragment, private val navController: NavContro
     mainNavController.navigate(resId = R.id.action_navigate_to_settings, args = bundle)
   }
 
-  fun showPromoCodeFragment() {
-    navigate(navController, RewardFragmentDirections.actionNavigatePromoCode())
+  fun showPromoCodeFragment(promoCode: String? = null) {
+    navigate(navController, RewardFragmentDirections.actionNavigatePromoCode(promoCode))
   }
 
   fun showGiftCardFragment(giftCard: String? = null) {

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -19,6 +19,11 @@
           android:defaultValue="@null"
           app:argType="string"
           app:nullable="true" />
+      <argument
+          android:name="promoCode"
+          android:defaultValue="@null"
+          app:argType="string"
+          app:nullable="true" />
     </action>
     <action
         android:id="@+id/action_navigate_to_onboarding_graph"

--- a/app/src/main/res/navigation/reward_graph.xml
+++ b/app/src/main/res/navigation/reward_graph.xml
@@ -16,7 +16,13 @@
       android:name="com.asfoundation.wallet.wallet_reward.RewardFragment">
     <action
         android:id="@+id/action_navigate_promo_code"
-        app:destination="@id/promo_code_fragment" />
+        app:destination="@id/promo_code_fragment" >
+      <argument
+          android:name="promoCode"
+          android:defaultValue="@null"
+          app:argType="string"
+          app:nullable="true"/>
+    </action>
     <action
         android:id="@+id/action_navigate_gift_card"
         app:destination="@id/gift_card_fragment" >

--- a/convention/src/main/java/com/appcoins/wallet/convention/plugins/AndroidAppPlugin.kt
+++ b/convention/src/main/java/com/appcoins/wallet/convention/plugins/AndroidAppPlugin.kt
@@ -34,6 +34,7 @@ class AndroidAppPlugin : Plugin<Project> {
         ndkVersion = Config.android.ndkVersion
         defaultConfig {
           val giftCardHost = "giftcard"
+          val promoCodeHost = "promocode"
           targetSdk = Config.android.targetSdk
           multiDexEnabled = true
           lint {
@@ -46,6 +47,9 @@ class AndroidAppPlugin : Plugin<Project> {
                 "${project.projectDir}/schemas"
             }
           }
+
+          buildConfigField("String", "PROMO_CODE_HOST", "\"$promoCodeHost\"")
+          manifestPlaceholders["promoCodeHost"] = promoCodeHost
 
           buildConfigField("String", "GIFT_CARD_HOST", "\"$giftCardHost\"")
           manifestPlaceholders["giftCardHost"] = giftCardHost


### PR DESCRIPTION
**What does this PR do?**

   This PR opens the promocode bottom sheet and adds the promocode automatically to the text field.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] NavBarFragment.kt
- [ ] NavBarFragmentNavigator.kt
- [ ] MainActivity.kt
- [ ] MainActivityNavigator.kt
- [ ] MainActivityViewModel.kt
- [ ] PromoCodeBottomSheetFragment.kt
- [ ] RewardFragment.kt
- [ ] RewardNavigator.kt
- [ ] main_graph.xml
- [ ] reward_graph.xml
- [ ] AndroidManifest.xml
- [ ] AndroidAppPlugin.kt


**How should this be manually tested?**

  Open the app to validate that it opens normally.
  Also use a deeplink to open the app. This can be done using the following prompt command:
  `adb shell am start -W -a android.intent.action.VIEW -d "appcoins://promocode?promocode=12345"`

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4445](https://aptoide.atlassian.net/browse/APPC-4445)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass

[APPC-4445]: https://aptoide.atlassian.net/browse/APPC-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ