### PR TITLE
[APPC-4167] Fix IAP credit card window size changes

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
@@ -7,6 +7,7 @@ import cm.aptoide.skills.SkillsActivity
 import com.airbnb.lottie.LottieAnimationView
 import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.core.walletservices.WalletService
+import com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus
 import com.asf.wallet.R
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.main.MainActivity
@@ -59,8 +60,8 @@ class OneStepPaymentReceiver : BaseActivity() {
     walletCreationText = findViewById(R.id.create_wallet_text)
     if (savedInstanceState == null) {
       disposable = handleWalletCreationIfNeeded()
-        .takeUntil { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
-        .filter { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
+        .takeUntil { it != WalletGetterStatus.CREATING.toString() }
+        .filter { it != WalletGetterStatus.CREATING.toString() }
         .flatMap {
           if (isEskillsUri(intent.dataString!!)) {
             val skillsActivityIntent = Intent(this, SkillsActivity::class.java)
@@ -140,11 +141,11 @@ class OneStepPaymentReceiver : BaseActivity() {
     walletService.findWalletOrCreate()
       .observeOn(AndroidSchedulers.mainThread())
       .doOnNext {
-        if (it == com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString()) {
+        if (it == WalletGetterStatus.CREATING.toString()) {
           showLoadingAnimation()
         }
       }
-      .filter { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
+      .filter { it != WalletGetterStatus.CREATING.toString() }
       .map {
         endAnimation()
         it

--- a/app/src/main/res/layout-land/adyen_credit_card_layout.xml
+++ b/app/src/main/res/layout-land/adyen_credit_card_layout.xml
@@ -92,19 +92,27 @@
           tools:visibility="visible"
           />
 
+      <LinearLayout
+          android:id="@+id/loading_container"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_margin="50dp"
+          android:orientation="vertical"
+          android:gravity="center"
+          android:visibility="gone"
+          app:layout_constraintBottom_toTopOf="@id/bottom_separator"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="@id/mid_guideline"
+          app:layout_constraintTop_toTopOf="parent">
+
       <com.airbnb.lottie.LottieAnimationView
           android:id="@+id/fragment_credit_card_authorization_progress_bar"
           android:layout_width="112dp"
           android:layout_height="112dp"
-          app:layout_constraintBottom_toTopOf="@id/bottom_separator"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="@id/mid_guideline"
-          app:layout_constraintTop_toTopOf="parent"
           app:lottie_autoPlay="true"
           app:lottie_enableMergePathsForKitKatAndAbove="true"
           app:lottie_loop="true"
           app:lottie_rawRes="@raw/loading_wallet"
-          tools:visibility="gone"
           />
 
       <TextView
@@ -115,14 +123,11 @@
           android:layout_marginStart="@dimen/big_margin"
           android:layout_marginTop="0dp"
           android:layout_marginEnd="@dimen/big_margin"
-          android:text="@string/purchase_making_purchase_title"
           android:visibility="gone"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="@id/mid_separator"
-          app:layout_constraintTop_toBottomOf="@+id/fragment_credit_card_authorization_progress_bar"
-          tools:visibility="gone"
+          android:text="@string/purchase_making_purchase_title"
           />
 
+      </LinearLayout>
       <androidx.constraintlayout.widget.ConstraintLayout
           android:id="@+id/cl_payment_container"
           android:layout_width="0dp"

--- a/app/src/main/res/layout/adyen_credit_card_layout.xml
+++ b/app/src/main/res/layout/adyen_credit_card_layout.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content"
     android:layout_gravity="center"
     android:animateLayoutChanges="true"
-    android:background="@drawable/background_content_payments"
+    android:background="@color/styleguide_payments_blue"
     android:theme="@style/AdyenMaterialAppTheme"
     >
   <RelativeLayout
@@ -21,6 +21,7 @@
         android:id="@+id/credit_card_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
         android:background="@drawable/background_rounded_styleguide_payments"
         android:clickable="true"
         android:elevation="2dp"
@@ -33,7 +34,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginStart="16dp"
-          android:layout_marginEnd="32dp"
+          android:layout_marginEnd="16dp"
           app:layout_constraintBottom_toTopOf="@id/cl_payment_container"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -43,6 +44,7 @@
           android:id="@+id/cl_payment_container"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:animateLayoutChanges="true"
           app:layout_constraintBottom_toTopOf="@id/bonus_layout"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -53,7 +55,7 @@
             android:id="@+id/cc_info_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
+            android:paddingStart="16dp"
             android:overScrollMode="never"
             android:scrollbars="none"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -66,6 +68,7 @@
           <RelativeLayout
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+              android:animateLayoutChanges="true"
               >
 
             <include
@@ -114,11 +117,11 @@
             android:layout_marginTop="1dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="8dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/adyen_saved_card"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:visibility="gone"
             tools:visibility="visible"
             />
 
@@ -138,39 +141,46 @@
             tools:visibility="gone"
             />
 
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/fragment_credit_card_authorization_progress_bar"
-            android:layout_width="112dp"
-            android:layout_height="112dp"
+        <LinearLayout
+            android:id="@+id/loading_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="50dp"
+            android:layout_marginBottom="58dp"
+            android:gravity="center"
+            android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:lottie_autoPlay="true"
-            app:lottie_enableMergePathsForKitKatAndAbove="true"
-            app:lottie_loop="true"
-            app:lottie_rawRes="@raw/loading_wallet"
             tools:visibility="visible"
-            />
+            >
 
-        <TextView
-            android:id="@+id/making_purchase_text"
-            style="@style/PaymentLoadingTextStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/big_margin"
-            android:layout_marginTop="-16dp"
-            android:layout_marginEnd="@dimen/big_margin"
-            android:gravity="center_horizontal"
-            android:text="@string/purchase_making_purchase_title"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/fragment_credit_card_authorization_progress_bar"
-            />
+          <com.airbnb.lottie.LottieAnimationView
+              android:id="@+id/fragment_credit_card_authorization_progress_bar"
+              android:layout_width="112dp"
+              android:layout_height="112dp"
+              app:lottie_autoPlay="true"
+              app:lottie_enableMergePathsForKitKatAndAbove="true"
+              app:lottie_loop="true"
+              app:lottie_rawRes="@raw/loading_wallet"
+              />
+
+          <TextView
+              android:id="@+id/making_purchase_text"
+              style="@style/PaymentLoadingTextStyle"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="@dimen/big_margin"
+              android:layout_marginEnd="@dimen/big_margin"
+              android:gravity="center_horizontal"
+              android:text="@string/purchase_making_purchase_title"
+              android:visibility="gone"
+              />
+
+        </LinearLayout>
 
       </androidx.constraintlayout.widget.ConstraintLayout>
-
 
       <include
           android:id="@+id/bonus_layout"
@@ -180,7 +190,7 @@
           android:layout_below="@id/cl_payment_container"
           android:layout_marginStart="@dimen/big_margin"
           android:layout_marginEnd="@dimen/big_margin"
-          android:visibility="invisible"
+          android:visibility="gone"
           app:layout_constraintBottom_toTopOf="@id/dialog_buy_buttons"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -204,6 +214,15 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/bonus_layout"
+          />
+
+      <androidx.constraintlayout.widget.Group
+          android:id="@+id/buttonsGroup"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:visibility="gone"
+          app:constraint_referenced_ids="bottom_separator_buttons_cc,dialog_buy_buttons "
+          tools:visibility="visible"
           />
 
       <com.appcoins.wallet.ui.widgets.SeparatorView
@@ -267,39 +286,32 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cv_legal_disclaimer"
+    <TextView
+        android:id="@+id/tv_legal_disclaimer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/styleguide_payments_blue"
-        android:layout_alignParentStart="true"
         android:layout_below="@id/credit_card_info"
+        android:layout_alignParentStart="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:background="@color/styleguide_payments_blue"
+        android:text="@string/purchase_legal_disclaimer"
+        android:textColor="@color/styleguide_dark_grey"
+        android:textSize="10sp"
         android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible"
-        >
-
-      <TextView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="16dp"
-          android:layout_marginEnd="16dp"
-          android:layout_marginBottom="8dp"
-          android:layout_marginTop="8dp"
-          android:text="@string/purchase_legal_disclaimer"
-          android:textColor="@color/styleguide_dark_grey"
-          android:textSize="10dp"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          />
-
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        />
 
     <include
         android:id="@+id/fragment_iab_transaction_completed"
         layout="@layout/fragment_iab_transaction_completed"
+        android:animateLayoutChanges="true"
         tools:visibility="gone"
         />
 


### PR DESCRIPTION
**What does this PR do?**

   Fixed credit card IAP layout jumps with an animation.
   Also did a small refactor on OneStepPaymentReceiver.kt.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AdyenPaymentFragment.kt
- [ ] adyen_credit_card_layout.xml
- [ ] OneStepPaymentReceiver.kt

**How should this be manually tested?**

  Start an IAP. Open credit card payment screen. Check the animations.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4167](https://aptoide.atlassian.net/browse/APPC-4167)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4167]: https://aptoide.atlassian.net/browse/APPC-4167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ