### PR TITLE
[APPC-4472] Vip promo codes not allow to add their own promo code

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
@@ -22,6 +22,8 @@ import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.core.utils.jvm_common.SyncExecutor
 import com.appcoins.wallet.core.utils.properties.MiscProperties
 import com.appcoins.wallet.core.walletservices.WalletService
+import com.appcoins.wallet.feature.promocode.data.wallet.WalletAddress
+import com.appcoins.wallet.feature.walletInfo.data.wallet.repository.WalletRepositoryType
 import com.aptoide.apk.injector.extractor.data.Extractor
 import com.aptoide.apk.injector.extractor.data.ExtractorV1
 import com.aptoide.apk.injector.extractor.data.ExtractorV2
@@ -33,6 +35,7 @@ import com.asf.wallet.R
 import com.asfoundation.wallet.entity.NetworkInfo
 import com.asfoundation.wallet.logging.DebugReceiver
 import com.asfoundation.wallet.logging.WalletLogger
+import com.asfoundation.wallet.promo_code.bottom_sheet.WalletsAddressProvider
 import com.asfoundation.wallet.repository.Web3jProvider
 import com.asfoundation.wallet.ui.iab.AppCoinsOperationRepository
 import com.asfoundation.wallet.ui.iab.AppInfoProvider
@@ -270,4 +273,9 @@ internal class AppModule {
   fun providesNetworkMonitorManager(@ApplicationContext context: Context): NetworkMonitor {
     return InternetManagerNetworkMonitor(context)
   }
+
+  @Singleton
+  @Provides
+  fun provideWalletAddress(walletRepository: WalletRepositoryType): WalletAddress =
+    WalletsAddressProvider(walletRepository)
 }

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/WalletsAddressProvider.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/WalletsAddressProvider.kt
@@ -1,0 +1,14 @@
+package com.asfoundation.wallet.promo_code.bottom_sheet
+
+import com.appcoins.wallet.feature.promocode.data.wallet.WalletAddress
+import com.appcoins.wallet.feature.walletInfo.data.wallet.repository.WalletRepositoryType
+import io.reactivex.Single
+
+class WalletsAddressProvider(
+  private val walletRepository: WalletRepositoryType,
+) : WalletAddress {
+
+  override fun getWalletAddresses(): Single<List<String>> =
+    walletRepository.fetchWallets()
+      .map { it.map { wallet -> wallet.address } }
+}

--- a/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promo_code/bottom_sheet/entry/PromoCodeBottomSheetFragment.kt
@@ -209,6 +209,10 @@ class PromoCodeBottomSheetFragment :
         )
       }
 
+      is FailedPromoCode.UserOwnPromoCode -> {
+        views.promoCodeBottomSheetString.setError(getString(R.string.vip_program_code_error_body))
+      }
+
       is FailedPromoCode.GenericError -> {
         views.promoCodeBottomSheetString.setError(getString(R.string.promo_code_error_invalid_user))
       }

--- a/app/src/main/res/layout/settings_promo_code_bottom_sheet_layout.xml
+++ b/app/src/main/res/layout/settings_promo_code_bottom_sheet_layout.xml
@@ -86,7 +86,8 @@
           app:layout_constraintTop_toBottomOf="@id/promo_code_bottom_sheet_subtitle"
           app:textFieldColor="@color/styleguide_blue"
           app:textFieldHint="@string/promo_code_view_field"
-          app:textFieldType="filled"
+          app:textFieldType="all_caps"
+          app:digitsRegex="[^A-Z0-9]"
           />
 
       <ImageView

--- a/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/model/PromoCodeBonusResponse.kt
+++ b/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/model/PromoCodeBonusResponse.kt
@@ -2,7 +2,12 @@ package com.appcoins.wallet.core.network.backend.model
 
 import com.google.gson.annotations.SerializedName
 
-data class PromoCodeBonusResponse(val code: String, val bonus: Double? = null, val app: App) {
+data class PromoCodeBonusResponse(
+  val code: String,
+  val bonus: Double? = null,
+  val app: App,
+  @SerializedName("owner_wallet") val ownerWallet: String?
+) {
 
   data class App(
     @SerializedName("package_name") val packageName: String?,

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/PromoCodeResult.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/PromoCodeResult.kt
@@ -12,6 +12,7 @@ sealed class FailedPromoCode : PromoCodeResult() {
   data class InvalidCode(val throwable: Throwable? = null) : FailedPromoCode()
   data class ExpiredCode(val throwable: Throwable? = null) : FailedPromoCode()
   data class CodeNotAdded(val throwable: Throwable? = null) : FailedPromoCode()
+  object UserOwnPromoCode : FailedPromoCode()
 }
 
 class PromoCodeMapper {
@@ -21,6 +22,7 @@ class PromoCodeMapper {
       ValidityState.EXPIRED -> FailedPromoCode.ExpiredCode()
       ValidityState.ERROR -> FailedPromoCode.InvalidCode()
       ValidityState.NOT_ADDED -> FailedPromoCode.CodeNotAdded()
+      ValidityState.USER_OWN_PROMO_CODE-> FailedPromoCode.UserOwnPromoCode
       else -> FailedPromoCode.CodeNotAdded()
     }
   }

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/error/UserOwnPromoCode.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/error/UserOwnPromoCode.kt
@@ -1,0 +1,3 @@
+package com.appcoins.wallet.feature.promocode.data.error
+
+class UserOwnPromoCode : Throwable()

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCode.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCode.kt
@@ -13,7 +13,8 @@ enum class ValidityState(val value: Int) {
   ACTIVE(0),
   EXPIRED(1),
   ERROR(2),
-  NOT_ADDED(3);
+  NOT_ADDED(3),
+  USER_OWN_PROMO_CODE(4);
 
   companion object {
     fun toEnum(value: Int) = ValidityState.values().firstOrNull { it.value == value }

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCodeRepository.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCodeRepository.kt
@@ -4,6 +4,8 @@ import com.appcoins.wallet.core.analytics.analytics.AnalyticsSetup
 import com.appcoins.wallet.core.network.backend.api.PromoCodeApi
 import com.appcoins.wallet.core.network.backend.model.PromoCodeBonusResponse
 import com.appcoins.wallet.core.utils.android_common.RxSchedulers
+import com.appcoins.wallet.feature.promocode.data.error.UserOwnPromoCode
+import com.appcoins.wallet.feature.promocode.data.wallet.WalletAddress
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -12,13 +14,23 @@ import javax.inject.Inject
 
 class PromoCodeRepository @Inject constructor(
   private val promoCodeApi: PromoCodeApi,
+  private val walletAddress: WalletAddress,
   private val promoCodeLocalDataSource: PromoCodeLocalDataSource,
   private val analyticsSetup: AnalyticsSetup,
   private val rxSchedulers: RxSchedulers
 ) {
 
-  fun verifyAndSavePromoCode(promoCodeString: String): Single<PromoCode> {
-    return promoCodeApi.getPromoCodeBonus(promoCodeString)
+  fun verifyAndSavePromoCode(
+    promoCodeString: String,
+  ): Single<PromoCode> {
+    return Single.zip(
+      walletAddress.getWalletAddresses().map { it.map { address -> address.lowercase() } },
+      promoCodeApi.getPromoCodeBonus(promoCodeString)
+    ) { walletAddresses, promoCodeResponse ->
+      if (!walletAddresses.contains(promoCodeResponse.ownerWallet?.lowercase())) {
+        promoCodeResponse
+      } else throw UserOwnPromoCode()
+    }
       .subscribeOn(rxSchedulers.io)
       .doOnSuccess { response ->
         analyticsSetup.setPromoCode(
@@ -27,7 +39,10 @@ class PromoCodeRepository @Inject constructor(
           validity = ValidityState.ACTIVE.value,
           appName = response.app.appName
         )
-        promoCodeLocalDataSource.savePromoCode(response, ValidityState.ACTIVE).subscribe()
+        promoCodeLocalDataSource.savePromoCode(
+          promoCodeBonus = response,
+          validity = ValidityState.ACTIVE
+        ).subscribe()
       }
       .map {
         PromoCode(
@@ -38,8 +53,17 @@ class PromoCodeRepository @Inject constructor(
         )
       }
       .onErrorReturn {
-        val errorCode = (it as? HttpException)?.code()
-        handleErrorCodes(errorCode, promoCodeString)
+        if (it is UserOwnPromoCode) {
+          PromoCode(
+            code = promoCodeString,
+            bonus = null,
+            validity = ValidityState.USER_OWN_PROMO_CODE,
+            appName = null
+          )
+        } else {
+          val errorCode = (it as? HttpException)?.code()
+          handleErrorCodes(errorCode, promoCodeString)
+        }
       }
   }
 

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCodeRepository.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/repository/PromoCodeRepository.kt
@@ -22,19 +22,19 @@ class PromoCodeRepository @Inject constructor(
       .subscribeOn(rxSchedulers.io)
       .doOnSuccess { response ->
         analyticsSetup.setPromoCode(
-          response.code,
-          response.bonus,
+          code = response.code,
+          bonus = response.bonus,
           validity = ValidityState.ACTIVE.value,
-          response.app.appName
+          appName = response.app.appName
         )
         promoCodeLocalDataSource.savePromoCode(response, ValidityState.ACTIVE).subscribe()
       }
       .map {
         PromoCode(
-          it.code,
-          it.bonus,
+          code = it.code,
+          bonus = it.bonus,
           validity = ValidityState.ACTIVE,
-          it.app.appName
+          appName = it.app.appName
         )
       }
       .onErrorReturn {
@@ -47,12 +47,13 @@ class PromoCodeRepository @Inject constructor(
     val validity = when (errorCode) {
       409 -> {
         promoCodeLocalDataSource.savePromoCode(
-          PromoCodeBonusResponse(
-            promoCodeString,
-            null,
-            PromoCodeBonusResponse.App(null, null, null)
+          promoCodeBonus = PromoCodeBonusResponse(
+            code = promoCodeString,
+            bonus = null,
+            app = PromoCodeBonusResponse.App(null, null, null),
+            ownerWallet = null
           ),
-          ValidityState.EXPIRED
+          validity = ValidityState.EXPIRED
         ).subscribe()
         ValidityState.EXPIRED
       }
@@ -61,10 +62,10 @@ class PromoCodeRepository @Inject constructor(
       else -> ValidityState.ERROR
     }
     return PromoCode(
-      promoCodeString,
-      null,
+      code = promoCodeString,
+      bonus = null,
       validity = validity,
-      null
+      appName = null
     )
   }
 

--- a/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/wallet/WalletAddress.kt
+++ b/feature/promo-code/data/src/main/java/com/appcoins/wallet/feature/promocode/data/wallet/WalletAddress.kt
@@ -1,0 +1,7 @@
+package com.appcoins.wallet.feature.promocode.data.wallet
+
+import io.reactivex.Single
+
+interface WalletAddress {
+  fun getWalletAddresses(): Single<List<String>>
+}

--- a/ui/common/src/main/res/values/styles_views.xml
+++ b/ui/common/src/main/res/values/styles_views.xml
@@ -35,9 +35,11 @@
       <enum name="password" value="2" />
       <enum name="read_only" value="3" />
       <enum name="number" value="4" />
+      <enum name="all_caps" value="5" />
     </attr>
     <attr name="textFieldHint" format="string" />
     <attr name="textFieldColor" format="color" />
+    <attr name="digitsRegex" format="string" />
   </declare-styleable>
 
   <declare-styleable name="AnimatedTextSwitcher">

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/WalletTextFieldView.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/WalletTextFieldView.kt
@@ -2,6 +2,7 @@ package com.appcoins.wallet.ui.widgets
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.text.InputFilter
 import android.text.InputType
 import android.text.TextWatcher
 import android.util.AttributeSet
@@ -42,6 +43,11 @@ class WalletTextFieldView : FrameLayout {
     setHint(hint)
     val textFieldColor = typedArray.getColor(R.styleable.WalletTextFieldView_textFieldColor, color)
     setColor(textFieldColor)
+    val regex = typedArray.getString(R.styleable.WalletTextFieldView_digitsRegex)
+    regex?.let {
+      val filter = InputFilter { source, start, end, _, _, _ -> source?.subSequence(start, end)?.replace(Regex(it), "") }
+      views.textInputEditText.filters += filter
+    }
     typedArray.recycle()
   }
 
@@ -73,6 +79,21 @@ class WalletTextFieldView : FrameLayout {
 
   private fun applyType() {
     when (type) {
+      Type.ALL_CAPS -> {
+        views.textInputEditText.setReadOnly(value = false, inputType = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS)
+        views.textInputEditText.isAllCaps = true
+        views.textInputEditText.filters += InputFilter.AllCaps()
+        views.textInputLayout.boxBackgroundColor =
+          ContextCompat.getColor(this.context, R.color.styleguide_blue)
+        views.textInputLayout.boxStrokeColor =
+          ContextCompat.getColor(this.context, R.color.transparent)
+        views.textInputLayout.boxStrokeWidth = 0
+        views.textInputLayout.endIconMode = END_ICON_NONE
+        views.textInputLayout.editText?.setTextColor(resources.getColor(R.color.styleguide_white))
+        views.textInputLayout.editText?.setHintTextColor(
+          resources.getColor(R.color.styleguide_dark_grey)
+        )
+      }
       Type.FILLED -> {
         views.textInputEditText.setReadOnly(value = false, inputType = InputType.TYPE_CLASS_TEXT)
         views.textInputLayout.boxBackgroundColor =
@@ -144,6 +165,7 @@ class WalletTextFieldView : FrameLayout {
     OUTLINED,
     PASSWORD,
     READ_ONLY,
-    NUMBER
+    NUMBER,
+    ALL_CAPS
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Added logic to show error when user wants to add his own promo code. Also created a new type for the WalletTextFieldView to accept a regex for the input and also to have the text all caps.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] settings_promo_code_bottom_sheet_layout.xml
- [ ] styles_views.xml
- [ ] WalletTextFieldView.kt
- [ ] AppModule.kt
- [ ] PromoCodeBottomSheetFragment.kt
- [ ] WalletsAddressProvider.kt
- [ ] PromoCodeBonusResponse.kt
- [ ] UserOwnPromoCode.kt
- [ ] PromoCode.kt
- [ ] PromoCodeRepository.kt
- [ ] WalletAddress.kt
- [ ] PromoCodeResult.kt

**How should this be manually tested?**

  Go to the promo code bottom sheet. Try do add special characters and non-caps letters. Validate that you can only add numbers and capitalized letters.
  Try to add your own promo code. Validate the error message and that the promo code is not used.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4472](https://aptoide.atlassian.net/browse/APPC-4472)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4472]: https://aptoide.atlassian.net/browse/APPC-4472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ