### PR TITLE
[APPC 4493] Cursor on bottom sheet text

### DIFF
--- a/app/src/main/res/layout/home_manage_wallet_bottom_sheet_layout.xml
+++ b/app/src/main/res/layout/home_manage_wallet_bottom_sheet_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/home_manage_wallet_bottom_sheet_layout"
     android:layout_width="match_parent"
@@ -9,29 +9,26 @@
     android:clipToPadding="false"
     android:orientation="vertical"
     android:paddingHorizontal="@dimen/half_large_margin"
-    android:paddingBottom="@dimen/half_large_margin"
+    android:paddingBottom="@dimen/big_margin"
     android:theme="@style/MaterialAppTheme"
     >
 
   <ImageView
       android:id="@+id/draggable_bar"
-      android:layout_width="0dp"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/normal_margin"
+      android:contentDescription="@null"
       android:src="@drawable/pull_up_home_bar"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
       />
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <androidx.appcompat.widget.LinearLayoutCompat
       android:id="@+id/manage_wallet_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="32dp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/draggable_bar"
+      android:layout_marginTop="@dimen/big_margin"
+      android:orientation="horizontal"
+      android:paddingVertical="@dimen/big_margin"
       >
 
     <ImageView
@@ -39,12 +36,12 @@
         android:layout_width="20dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
         android:src="@drawable/ic_manage_wallet"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         />
 
     <TextView
+        android:id="@+id/manage_wallet_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
@@ -53,33 +50,28 @@
         android:text="@string/manage_wallet_button"
         android:textColor="@color/styleguide_light_grey"
         android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="@id/manage_wallet_img"
-        app:layout_constraintStart_toEndOf="@id/manage_wallet_img"
-        app:layout_constraintTop_toTopOf="@id/manage_wallet_img"
         />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.appcompat.widget.LinearLayoutCompat>
 
-
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <androidx.appcompat.widget.LinearLayoutCompat
       android:id="@+id/recover_wallet_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="32dp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/manage_wallet_view"
+      android:orientation="horizontal"
+      android:paddingVertical="@dimen/big_margin"
       >
+
     <ImageView
         android:id="@+id/recover_wallet_icon"
         android:layout_width="20dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
         android:src="@drawable/ic_recover_wallet"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         />
 
     <TextView
+        android:id="@+id/recover_wallet_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
@@ -88,21 +80,15 @@
         android:text="@string/my_wallets_action_recover_wallet"
         android:textColor="@color/styleguide_light_grey"
         android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="@id/recover_wallet_icon"
-        app:layout_constraintStart_toEndOf="@id/recover_wallet_icon"
-        app:layout_constraintTop_toTopOf="@id/recover_wallet_icon"
         />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.appcompat.widget.LinearLayoutCompat>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <androidx.appcompat.widget.LinearLayoutCompat
       android:id="@+id/backup_wallet_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="32dp"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/recover_wallet_view"
+      android:orientation="horizontal"
+      android:paddingVertical="@dimen/big_margin"
       >
 
     <ImageView
@@ -110,13 +96,13 @@
         android:layout_width="20dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
         android:src="@drawable/ic_backup_white"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/styleguide_pink"
         />
 
     <TextView
+        android:id="@+id/backup_wallet_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
@@ -125,10 +111,7 @@
         android:text="@string/my_wallets_action_backup_wallet"
         android:textColor="@color/styleguide_light_grey"
         android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="@id/backup_wallet_icon"
-        app:layout_constraintStart_toEndOf="@id/backup_wallet_icon"
-        app:layout_constraintTop_toTopOf="@id/backup_wallet_icon"
         />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.appcompat.widget.LinearLayoutCompat>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
**What does this PR do?**

   This screen had an issue that after opening settings screen, and the open the Manage Wallet bottom sheet, the "t's" on the end of "wallet" words would be obfuscated on the starting of the screen.
   Fixed this issue.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] home_manage_wallet_bottom_sheet_layout.xml

**How should this be manually tested?**

  Open settings screen. After that open the manage wallet bottom sheet.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4493](https://aptoide.atlassian.net/browse/APPC-4493)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4493]: https://aptoide.atlassian.net/browse/APPC-4493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ