### PR TITLE
[APPC-4494] Payment start add property oemId

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
@@ -969,7 +969,7 @@ class AdyenPaymentFragment : BasePageViewFragment() {
   private fun handlePreSelectedView() {
     if (!isPreSelected) {
       cancelButton.setText(getString(R.string.back_button))
-      iabView.disableBack()
+      iabView.setBackEnable(false)
     }
   }
 
@@ -1031,7 +1031,7 @@ class AdyenPaymentFragment : BasePageViewFragment() {
   }
 
   override fun onDestroyView() {
-    iabView.enableBack()
+    iabView.setBackEnable(true)
     viewModel.cancelPaypalLaunch = true
 //    presenter.stop()
     super.onDestroyView()

--- a/app/src/main/java/com/asfoundation/wallet/billing/googlepay/GooglePayWebFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/googlepay/GooglePayWebFragment.kt
@@ -49,7 +49,7 @@ class GooglePayWebFragment : BasePageViewFragment() {
     binding = FragmentGooglePayWebBinding.inflate(inflater, container, false)
     compositeDisposable = CompositeDisposable()
     navigatorIAB = IabNavigator(parentFragmentManager, activity as UriNavigator?, iabView)
-    iabView.disableBack()
+    iabView.setBackEnable(false)
     return views.root
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/di/RxSchedulers.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/RxSchedulers.kt
@@ -1,0 +1,37 @@
+package com.asfoundation.wallet.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class RxSchedulers {
+
+  @NetworkDispatcher
+  @Singleton
+  @Provides
+  fun provideNetworkDispatcher(): Scheduler =
+    Schedulers.io()
+
+  @ViewDispatcher
+  @Singleton
+  @Provides
+  fun provideViewDispatcher(): Scheduler =
+    AndroidSchedulers.mainThread()
+
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NetworkDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ViewDispatcher

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
@@ -93,7 +93,7 @@ class OnboardingPaymentEvents @Inject constructor(
   }
 
   fun sendPurchaseStartWithoutDetailsEvent(transactionBuilder: TransactionBuilder) {
-    billingAnalytics.sendPurchaseStartWithoutDetailsEvent(
+    billingAnalytics.sendPurchaseStartEvent(
       packageName = transactionBuilder.domain,
       skuDetails = transactionBuilder.skuId,
       value = transactionBuilder.amount().toString(),

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
@@ -92,13 +92,14 @@ class OnboardingPaymentEvents @Inject constructor(
     )
   }
 
-  fun sendPurchaseStartWithoutDetailsEvent(transactionBuilder: TransactionBuilder) {
+  fun sendPurchaseStartEvent(transactionBuilder: TransactionBuilder, oemId: String?) {
     billingAnalytics.sendPurchaseStartEvent(
       packageName = transactionBuilder.domain,
       skuDetails = transactionBuilder.skuId,
       value = transactionBuilder.amount().toString(),
       transactionType = transactionBuilder.type,
       context = BillingAnalytics.WALLET_PAYMENT_METHOD,
+      oemId = oemId,
       isOnboardingPayment = true
     )
   }

--- a/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding_new_payment/OnboardingPaymentEvents.kt
@@ -18,18 +18,17 @@ class OnboardingPaymentEvents @Inject constructor(
   private val analyticsManager: AnalyticsManager
 ) {
 
-
   fun sendPaymentConfirmationEvent(
     transactionBuilder: TransactionBuilder,
     paymentType: PaymentType
   ) {
     billingAnalytics.sendPaymentConfirmationEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      paymentType.mapToService().transactionType,
-      transactionBuilder.type,
-      BillingAnalytics.ACTION_BUY,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = paymentType.mapToService().transactionType,
+      transactionType = transactionBuilder.type,
+      action = BillingAnalytics.ACTION_BUY,
       isOnboardingPayment = true
     )
   }
@@ -41,16 +40,19 @@ class OnboardingPaymentEvents @Inject constructor(
     refusalReason: String? = null,
     riskRules: String? = null
   ) {
-    stopTimingForPurchaseEvent(success = false, paymentType)
+    stopTimingForPurchaseEvent(
+      success = false,
+      paymentType = paymentType
+    )
     billingAnalytics.sendPaymentErrorWithDetailsAndRiskEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      paymentType.mapToService().transactionType,
-      transactionBuilder.type,
-      refusalCode.toString(),
-      refusalReason,
-      riskRules,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = paymentType.mapToService().transactionType,
+      transactionType = transactionBuilder.type,
+      errorCode = refusalCode.toString(),
+      errorDetails = refusalReason,
+      riskRules = riskRules,
       isOnboardingPayment = true
     )
   }
@@ -62,14 +64,14 @@ class OnboardingPaymentEvents @Inject constructor(
     paymentMethod: String,
   ) {
     billingAnalytics.sendPaymentErrorWithDetailsAndRiskEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      paymentMethod,
-      transactionBuilder.type,
-      errorCode ?: "",
-      errorMessage ?: "",
-      "",
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = paymentMethod,
+      transactionType = transactionBuilder.type,
+      errorCode = errorCode ?: "",
+      errorDetails = errorMessage ?: "",
+      riskRules = "",
       isOnboardingPayment = true
     )
   }
@@ -80,23 +82,23 @@ class OnboardingPaymentEvents @Inject constructor(
     action: String
   ) {
     paymentMethodsAnalytics.sendPaymentMethodEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      paymentType?.mapToService()?.transactionType ?: "other_payment_methods",
-      transactionBuilder.type,
-      action,
+      appPackage = transactionBuilder.domain,
+      skuId = transactionBuilder.skuId,
+      amount = transactionBuilder.amount().toString(),
+      paymentId = paymentType?.mapToService()?.transactionType ?: "other_payment_methods",
+      type = transactionBuilder.type,
+      action = action,
       isOnboardingPayment = true
     )
   }
 
   fun sendPurchaseStartWithoutDetailsEvent(transactionBuilder: TransactionBuilder) {
     billingAnalytics.sendPurchaseStartWithoutDetailsEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      transactionBuilder.type,
-      BillingAnalytics.WALLET_PAYMENT_METHOD,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      transactionType = transactionBuilder.type,
+      context = BillingAnalytics.WALLET_PAYMENT_METHOD,
       isOnboardingPayment = true
     )
   }
@@ -111,11 +113,11 @@ class OnboardingPaymentEvents @Inject constructor(
       isPreselected = false
     )
     billingAnalytics.sendPaymentEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      paymentType.mapToService().transactionType,
-      transactionBuilder.type,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = paymentType.mapToService().transactionType,
+      transactionType = transactionBuilder.type,
       isOnboardingPayment = true
     )
     billingAnalytics.sendRevenueEvent(revenueValueUseCase(transactionBuilder))
@@ -126,7 +128,10 @@ class OnboardingPaymentEvents @Inject constructor(
     paymentType: PaymentType,
     txId: String
   ) {
-    stopTimingForPurchaseEvent(success = true, paymentType)
+    stopTimingForPurchaseEvent(
+      success = true,
+      paymentType = paymentType
+    )
     billingAnalytics.sendPaymentSuccessEvent(
       packageName = transactionBuilder.domain,
       skuDetails = transactionBuilder.skuId,
@@ -141,13 +146,12 @@ class OnboardingPaymentEvents @Inject constructor(
 
   fun sendCarrierBillingConfirmationEvent(transactionBuilder: TransactionBuilder, action: String) {
     billingAnalytics.sendPaymentConfirmationEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount()
-        .toString(),
-      BillingAnalytics.PAYMENT_METHOD_CARRIER,
-      transactionBuilder.type,
-      action,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = BillingAnalytics.PAYMENT_METHOD_CARRIER,
+      transactionType = transactionBuilder.type,
+      action = action,
       isOnboardingPayment = true
     )
   }
@@ -158,13 +162,12 @@ class OnboardingPaymentEvents @Inject constructor(
     paymentType: String
   ) {
     billingAnalytics.sendPaymentConfirmationEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount()
-        .toString(),
-      paymentType,
-      transactionBuilder.type,
-      action,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = paymentType,
+      transactionType = transactionBuilder.type,
+      action = action,
       isOnboardingPayment = true
     )
   }
@@ -174,22 +177,20 @@ class OnboardingPaymentEvents @Inject constructor(
     data: Intent,
     paymentType: String
   ) {
-    val amountString = transactionBuilder.amount()
-      .toString()
+    val amountString = transactionBuilder.amount().toString()
     billingAnalytics.sendPaypalUrlEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      amountString, paymentType,
-      getQueryParameter(data, "type"),
-      getQueryParameter(data, "resultCode"),
-      data.dataString,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = amountString, transactionType = paymentType,
+      type = getQueryParameter(data, "type"),
+      resultCode = getQueryParameter(data, "resultCode"),
+      url = data.dataString,
       isOnboardingPayment = true
     )
   }
 
-  fun getQueryParameter(data: Intent, parameter: String): String? {
-    return Uri.parse(data.dataString)
-      .getQueryParameter(parameter)
+  private fun getQueryParameter(data: Intent, parameter: String): String? {
+    return Uri.parse(data.dataString).getQueryParameter(parameter)
   }
 
   fun startTimingForPurchaseEvent() {
@@ -198,8 +199,8 @@ class OnboardingPaymentEvents @Inject constructor(
 
   private fun stopTimingForPurchaseEvent(success: Boolean, paymentType: PaymentType) {
     paymentMethodsAnalytics.stopTimingForPurchaseEvent(
-      paymentType.mapToService().transactionType,
-      success,
+      paymentMethod = paymentType.mapToService().transactionType,
+      success = success,
       isPreselected = false
     )
   }
@@ -232,14 +233,20 @@ class OnboardingPaymentEvents @Inject constructor(
     packageName: String, skuId: String?, amount: String, type: String,
     paymentId: String
   ) {
-    billingAnalytics.sendPaymentMethodDetailsEvent(packageName, skuId, amount, paymentId, type)
+    billingAnalytics.sendPaymentMethodDetailsEvent(
+      packageName = packageName,
+      skuDetails = skuId,
+      value = amount,
+      purchaseDetails = paymentId,
+      transactionType = type
+    )
     billingAnalytics.sendPaymentConfirmationEvent(
-      packageName,
-      skuId,
-      amount,
-      paymentId,
-      type,
-      BillingAnalytics.ACTION_BUY
+      packageName = packageName,
+      skuDetails = skuId,
+      value = amount,
+      purchaseDetails = paymentId,
+      transactionType = type,
+      action = BillingAnalytics.ACTION_BUY
     )
   }
 
@@ -247,12 +254,12 @@ class OnboardingPaymentEvents @Inject constructor(
     transactionBuilder: TransactionBuilder,
   ) {
     billingAnalytics.sendPaymentConfirmationEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      BillingAnalytics.PAYMENT_METHOD_GOOGLE_PAY_WEB,
-      transactionBuilder.type,
-      BillingAnalytics.ACTION_BUY,
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = BillingAnalytics.PAYMENT_METHOD_GOOGLE_PAY_WEB,
+      transactionType = transactionBuilder.type,
+      action = BillingAnalytics.ACTION_BUY,
       isOnboardingPayment = true
     )
   }
@@ -276,22 +283,31 @@ class OnboardingPaymentEvents @Inject constructor(
       valueUsd = transactionBuilder.amountUsd.toString()
     )
     billingAnalytics.sendPaymentEvent(
-      transactionBuilder.domain,
-      transactionBuilder.skuId,
-      transactionBuilder.amount().toString(),
-      BillingAnalytics.PAYMENT_METHOD_GOOGLE_PAY_WEB,
-      transactionBuilder.type,
-      isOnboardingPayment = true
+      packageName = transactionBuilder.domain,
+      skuDetails = transactionBuilder.skuId,
+      value = transactionBuilder.amount().toString(),
+      purchaseDetails = BillingAnalytics.PAYMENT_METHOD_GOOGLE_PAY_WEB,
+      transactionType = transactionBuilder.type, isOnboardingPayment = true
     )
     billingAnalytics.sendRevenueEvent(revenueValueUseCase(transactionBuilder))
   }
 
   fun sendPaymentConclusionEvents(
-    packageName: String, skuId: String?, amount: BigDecimal,
-    type: String, paymentId: String, txId: String,
+    packageName: String,
+    skuId: String?,
+    amount: BigDecimal,
+    type: String,
+    paymentId: String,
+    txId: String,
     amountUsd: BigDecimal
   ) {
-    billingAnalytics.sendPaymentEvent(packageName, skuId, amount.toString(), paymentId, type)
+    billingAnalytics.sendPaymentEvent(
+      packageName = packageName,
+      skuDetails = skuId,
+      value = amount.toString(),
+      purchaseDetails = paymentId,
+      transactionType = type
+    )
     billingAnalytics.sendPaymentSuccessEvent(
       packageName = packageName,
       skuDetails = skuId,
@@ -301,14 +317,6 @@ class OnboardingPaymentEvents @Inject constructor(
       txId = txId,
       valueUsd = amountUsd.toString()
     )
-  }
-
-  fun sendPendingPaymentEvents(
-    packageName: String, skuId: String?, amount: String, type: String,
-    paymentId: String
-  ) {
-    billingAnalytics.sendPaymentEvent(packageName, skuId, amount, paymentId, type)
-    billingAnalytics.sendPaymentPendingEvent(packageName, skuId, amount, paymentId, type)
   }
 
   fun sendRevenueEvent(fiatAmount: String) = billingAnalytics.sendRevenueEvent(fiatAmount)

--- a/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/OneStepPaymentReceiver.kt
@@ -8,9 +8,9 @@ import com.airbnb.lottie.LottieAnimationView
 import com.appcoins.wallet.core.analytics.analytics.partners.PartnerAddressService
 import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.core.walletservices.WalletService
+import com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus
 import com.asf.wallet.R
 import com.asfoundation.wallet.entity.TransactionBuilder
-import com.asfoundation.wallet.main.MainActivity
 import com.asfoundation.wallet.ui.iab.IabActivity
 import com.asfoundation.wallet.ui.iab.IabActivity.Companion.newIntent
 import com.asfoundation.wallet.ui.iab.InAppPurchaseInteractor
@@ -64,8 +64,8 @@ class OneStepPaymentReceiver : BaseActivity() {
     partnerAddressService.setOemIdFromSdk("")
     if (savedInstanceState == null) {
       disposable = handleWalletCreationIfNeeded()
-        .takeUntil { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
-        .filter { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
+        .takeUntil { it != WalletGetterStatus.CREATING.toString() }
+        .filter { it != WalletGetterStatus.CREATING.toString() }
         .flatMap {
           if (isEskillsUri(intent.dataString!!)) {
             val skillsActivityIntent = Intent(this, SkillsActivity::class.java)
@@ -103,12 +103,6 @@ class OneStepPaymentReceiver : BaseActivity() {
     .lowercase(Locale.ROOT)
     .contains("/transaction/eskills")
 
-  private fun startApp(throwable: Throwable) {
-    throwable.printStackTrace()
-    startActivity(MainActivity.newIntent(this, supportNotificationClicked = false))
-    finish()
-  }
-
   private fun startOneStepTransfer(
     transaction: TransactionBuilder,
     isBds: Boolean
@@ -145,11 +139,11 @@ class OneStepPaymentReceiver : BaseActivity() {
     walletService.findWalletOrCreate()
       .observeOn(AndroidSchedulers.mainThread())
       .doOnNext {
-        if (it == com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString()) {
+        if (it == WalletGetterStatus.CREATING.toString()) {
           showLoadingAnimation()
         }
       }
-      .filter { it != com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus.CREATING.toString() }
+      .filter { it != WalletGetterStatus.CREATING.toString() }
       .map {
         endAnimation()
         it

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsFragment.kt
@@ -49,7 +49,7 @@ class EarnAppcoinsFragment : BasePageViewFragment(), EarnAppcoinsView {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     binding.dialogBuyButtonsPaymentMethods.buyButton.setText(getString(R.string.discover_button))
     binding.dialogBuyButtonsPaymentMethods.cancelButton.setText(getString(R.string.back_button))
-    iabView.disableBack()
+    iabView.setBackEnable(false)
     presenter.present()
     super.onViewCreated(view, savedInstanceState)
   }
@@ -74,7 +74,7 @@ class EarnAppcoinsFragment : BasePageViewFragment(), EarnAppcoinsView {
   override fun backPressed() = iabView.backButtonPress()
 
   override fun onDestroyView() {
-    iabView.enableBack()
+    iabView.setBackEnable(true)
     presenter.destroy()
     super.onDestroyView()
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
@@ -1,5 +1,6 @@
 package com.asfoundation.wallet.ui.iab
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
@@ -9,17 +10,14 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.appcoins.wallet.billing.AppcoinsBillingBinder
-import com.appcoins.wallet.billing.AppcoinsBillingBinder.Companion.EXTRA_BDS_IAP
 import com.appcoins.wallet.billing.repository.entity.TransactionData
-import com.appcoins.wallet.core.analytics.analytics.legacy.BillingAnalytics
 import com.appcoins.wallet.core.utils.android_common.NetworkMonitor
-import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.feature.challengereward.data.ChallengeRewardManager
-import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetShowRefundDisclaimerCodeUseCase
-import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.SetCachedShowRefundDisclaimerUseCase
 import com.appcoins.wallet.ui.widgets.NoNetworkCard
 import com.asf.wallet.BuildConfig
 import com.asf.wallet.R
@@ -35,7 +33,6 @@ import com.asfoundation.wallet.billing.vkpay.VkPaymentIABFragment
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.main.MainActivity
 import com.asfoundation.wallet.navigator.UriNavigator
-import com.asfoundation.wallet.promotions.usecases.StartVipReferralPollingUseCase
 import com.asfoundation.wallet.topup.TopUpActivity
 import com.asfoundation.wallet.transactions.PerkBonusAndGamificationService
 import com.asfoundation.wallet.ui.AuthenticationPromptActivity
@@ -43,18 +40,13 @@ import com.asfoundation.wallet.ui.iab.IabInteract.Companion.PRE_SELECTED_PAYMENT
 import com.asfoundation.wallet.ui.iab.localpayments.LocalPaymentFragment
 import com.asfoundation.wallet.ui.iab.payments.carrier.verify.CarrierVerifyFragment
 import com.asfoundation.wallet.ui.iab.share.SharePaymentLinkFragment
-import com.asfoundation.wallet.update_required.use_cases.GetAutoUpdateModelUseCase
-import com.asfoundation.wallet.update_required.use_cases.HasRequiredHardUpdateUseCase
+import com.asfoundation.wallet.util.getParcelable
 import com.asfoundation.wallet.verification.ui.credit_card.VerificationCreditCardActivity
-import com.asfoundation.wallet.wallet_blocked.WalletBlockedInteract
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxrelay2.PublishRelay
 import com.wallet.appcoins.core.legacy_base.BaseActivity
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import java.lang.Thread.sleep
 import java.math.BigDecimal
@@ -66,80 +58,39 @@ import javax.inject.Inject
 class IabActivity : BaseActivity(), IabView, UriNavigator {
 
   @Inject
-  lateinit var billingAnalytics: BillingAnalytics
-
-  @Inject
-  lateinit var iabInteract: IabInteract
-
-  @Inject
-  lateinit var startVipReferralPollingUseCase: StartVipReferralPollingUseCase
-
-  @Inject
-  lateinit var walletBlockedInteract: WalletBlockedInteract
-
-  @Inject
-  lateinit var autoUpdateModelUseCase: GetAutoUpdateModelUseCase
-
-  @Inject
-  lateinit var getShowRefundDisclaimerCodeUseCase: GetShowRefundDisclaimerCodeUseCase
-
-  @Inject
-  lateinit var setCachedShowRefundDisclaimerUseCase: SetCachedShowRefundDisclaimerUseCase
-
-  @Inject
-  lateinit var hasRequiredHardUpdateUseCase: HasRequiredHardUpdateUseCase
-
-  @Inject
-  lateinit var logger: Logger
-
-  @Inject
   lateinit var networkMonitor: NetworkMonitor
 
-  private lateinit var presenter: IabPresenter
-  private var isBackEnable: Boolean = false
-  private var transaction: TransactionBuilder? = null
-  private var isBds: Boolean = false
-  private var backButtonPress: PublishRelay<Any>? = null
-  private var results: PublishRelay<Uri>? = null
-  private var developerPayload: String? = null
-  private var uri: String? = null
-  private var authenticationResultSubject: PublishSubject<Boolean>? = null
-  private var errorFromReceiver: String? = null
+  @Inject
+  lateinit var presenter: IabPresenter
+
+  private var isBackEnable: Boolean = true
+
+  private val backButtonPress by lazy { PublishRelay.create<Any>() }
+  private val results by lazy { PublishRelay.create<Uri>() }
+  private val authenticationResultSubject by lazy { PublishSubject.create<Boolean>() }
+
+  private val transaction by lazy { intent.getParcelable<TransactionBuilder>(TRANSACTION_EXTRA) }
+  private val isBds by lazy { intent.getBooleanExtra(IS_BDS_EXTRA, false) }
+  private val developerPayload by lazy { intent.getStringExtra(DEVELOPER_PAYLOAD) }
+  private val uri by lazy { intent.getStringExtra(URI) }
+  private val errorFromReceiver by lazy { intent.getStringExtra(ERROR_RECEIVER) }
+
   override var webViewResultCode: String? = null
 
   private val binding by viewBinding(ActivityIabBinding::bind)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    backButtonPress = PublishRelay.create()
-    results = PublishRelay.create()
-    authenticationResultSubject = PublishSubject.create()
     setContentView(R.layout.activity_iab)
-    isBds = intent.getBooleanExtra(IS_BDS_EXTRA, false)
-    developerPayload = intent.getStringExtra(DEVELOPER_PAYLOAD)
-    uri = intent.getStringExtra(URI)
-    transaction = intent.getParcelableExtra(TRANSACTION_EXTRA)
-    errorFromReceiver = intent.getStringExtra(ERROR_RECEIVER)
-    isBackEnable = true
-    presenter = IabPresenter(
-      this,
-      Schedulers.io(),
-      AndroidSchedulers.mainThread(),
-      CompositeDisposable(),
-      billingAnalytics,
-      iabInteract,
-      autoUpdateModelUseCase,
-      hasRequiredHardUpdateUseCase,
-      startVipReferralPollingUseCase,
-      getShowRefundDisclaimerCodeUseCase,
-      setCachedShowRefundDisclaimerUseCase,
-      logger,
-      transaction,
-      errorFromReceiver
+    presenter.init(
+      view = this,
+      transaction = transaction,
+      errorFromReceiver = errorFromReceiver
     )
     presenter.present(savedInstanceState)
   }
 
+  @Deprecated("Deprecated in Java")
   @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
@@ -153,16 +104,15 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     presenter.onResume()
   }
 
+  @Suppress("DEPRECATION")
+  @Deprecated("Deprecated in Java")
   override fun onBackPressed() {
     if (isBackEnable) {
       val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
       if (fragment is OnBackPressedListener) {
         (fragment as OnBackPressedListener).onBackPressed()
       } else {
-        Bundle().apply {
-          putInt(RESPONSE_CODE, RESULT_USER_CANCELED)
-          close(this)
-        }
+        bundleOf(RESPONSE_CODE to RESULT_USER_CANCELED).apply { close(this) }
         super.onBackPressed()
       }
     } else {
@@ -170,12 +120,8 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     }
   }
 
-  override fun disableBack() {
-    isBackEnable = false
-  }
-
-  override fun enableBack() {
-    isBackEnable = true
+  override fun setBackEnable(enable: Boolean) {
+    isBackEnable = enable
   }
 
   override fun navigateBack() {
@@ -235,8 +181,8 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
       context = this,
       supportNotificationClicked = false,
       isPayPalVerificationRequired = true
-    )
-      .apply { intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP }
+    ).apply { intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP }
+
     startActivity(intent)
     finishWithError()
   }
@@ -248,19 +194,16 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     gamificationLevel: Int,
     transactionBuilder: TransactionBuilder
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        OnChainBuyFragment.newInstance(
-          createBundle(amount),
-          intent.data!!.toString(),
-          isBds,
-          transactionBuilder,
-          bonus,
-          gamificationLevel
-        )
+    replaceFragment(
+      OnChainBuyFragment.newInstance(
+        createBundle(amount),
+        intent.data!!.toString(),
+        isBds,
+        transactionBuilder,
+        bonus,
+        gamificationLevel
       )
-      .commit()
+    )
   }
 
   override fun showAdyenPayment(
@@ -275,26 +218,23 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        AdyenPaymentFragment.newInstance(
-          paymentType = paymentType,
-          origin = getOrigin(isBds),
-          transactionBuilder = transaction!!,
-          amount = amount,
-          currency = currency,
-          bonus = bonus,
-          isPreSelected = isPreselected,
-          gamificationLevel = gamificationLevel,
-          skuDescription = getSkuDescription(),
-          isSubscription = isSubscription,
-          isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
-          frequency = frequency,
-          paymentStateEnum = null
-        )
+    replaceFragment(
+      AdyenPaymentFragment.newInstance(
+        paymentType = paymentType,
+        origin = getOrigin(isBds),
+        transactionBuilder = transaction!!,
+        amount = amount,
+        currency = currency,
+        bonus = bonus,
+        isPreSelected = isPreselected,
+        gamificationLevel = gamificationLevel,
+        skuDescription = getSkuDescription(),
+        isSubscription = isSubscription,
+        isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
+        frequency = frequency,
+        paymentStateEnum = null
       )
-      .commit()
+    )
   }
 
   override fun showPayPalV2(
@@ -309,25 +249,22 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        PayPalIABFragment.newInstance(
-          paymentType = paymentType,
-          origin = getOrigin(isBds),
-          transactionBuilder = transaction!!,
-          amount = amount,
-          currency = currency,
-          bonus = bonus,
-          isPreSelected = isPreselected,
-          gamificationLevel = gamificationLevel,
-          skuDescription = getSkuDescription(),
-          isSubscription = isSubscription,
-          isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
-          frequency = frequency,
-        )
+    replaceFragment(
+      PayPalIABFragment.newInstance(
+        paymentType = paymentType,
+        origin = getOrigin(isBds),
+        transactionBuilder = transaction!!,
+        amount = amount,
+        currency = currency,
+        bonus = bonus,
+        isPreSelected = isPreselected,
+        gamificationLevel = gamificationLevel,
+        skuDescription = getSkuDescription(),
+        isSubscription = isSubscription,
+        isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
+        frequency = frequency,
       )
-      .commit()
+    )
   }
 
   override fun showSandbox(
@@ -342,25 +279,22 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        SandboxFragment.newInstance(
-          paymentType = paymentType,
-          origin = getOrigin(isBds),
-          transactionBuilder = transaction!!,
-          amount = amount,
-          currency = currency,
-          bonus = bonus,
-          isPreSelected = isPreselected,
-          gamificationLevel = gamificationLevel,
-          skuDescription = getSkuDescription(),
-          isSubscription = isSubscription,
-          isSkills = intent.dataString?.contains("&skills") ?: false,
-          frequency = frequency,
-        )
+    replaceFragment(
+      SandboxFragment.newInstance(
+        paymentType = paymentType,
+        origin = getOrigin(isBds),
+        transactionBuilder = transaction!!,
+        amount = amount,
+        currency = currency,
+        bonus = bonus,
+        isPreSelected = isPreselected,
+        gamificationLevel = gamificationLevel,
+        skuDescription = getSkuDescription(),
+        isSubscription = isSubscription,
+        isSkills = intent.dataString?.contains("&skills") ?: false,
+        frequency = frequency,
       )
-      .commit()
+    )
   }
 
   override fun showVkPay(
@@ -374,23 +308,22 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    val fragmentVk = VkPaymentIABFragment()
-    fragmentVk.arguments = Bundle().apply {
-      putString(VkPaymentIABFragment.PAYMENT_TYPE_KEY, paymentType.name)
-      putString(VkPaymentIABFragment.ORIGIN_KEY, getOrigin(isBds))
-      putParcelable(VkPaymentIABFragment.TRANSACTION_DATA_KEY, transaction!!)
-      putSerializable(VkPaymentIABFragment.AMOUNT_KEY, amount)
-      putString(VkPaymentIABFragment.CURRENCY_KEY, currency)
-      putString(VkPaymentIABFragment.BONUS_KEY, bonus)
-      putString(VkPaymentIABFragment.SKU_DESCRIPTION, getSkuDescription())
-      putBoolean(VkPaymentIABFragment.IS_SKILLS, intent.dataString?.contains(SKILLS_TAG) ?: false)
-      putString(VkPaymentIABFragment.FREQUENCY, frequency)
-    }
-    supportFragmentManager.beginTransaction()
-      .add(R.id.fragment_container, fragmentVk)
-      .addToBackStack(VkPaymentIABFragment::class.java.simpleName)
-      .commit()
-
+    addFragment(
+      fragment = VkPaymentIABFragment().apply {
+        arguments = bundleOf(
+          VkPaymentIABFragment.PAYMENT_TYPE_KEY to paymentType.name,
+          VkPaymentIABFragment.ORIGIN_KEY to getOrigin(isBds),
+          VkPaymentIABFragment.TRANSACTION_DATA_KEY to transaction!!,
+          VkPaymentIABFragment.AMOUNT_KEY to amount,
+          VkPaymentIABFragment.CURRENCY_KEY to currency,
+          VkPaymentIABFragment.BONUS_KEY to bonus,
+          VkPaymentIABFragment.SKU_DESCRIPTION to getSkuDescription(),
+          VkPaymentIABFragment.IS_SKILLS to intent.dataString?.contains(SKILLS_TAG),
+          VkPaymentIABFragment.FREQUENCY to frequency
+        )
+      },
+      addToBackStackName = VkPaymentIABFragment::class.java.simpleName
+    )
   }
 
   override fun showGooglePayWeb(
@@ -405,25 +338,22 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        GooglePayWebFragment.newInstance(
-          paymentType = paymentType,
-          origin = getOrigin(isBds),
-          transactionBuilder = transaction!!,
-          amount = amount,
-          currency = currency,
-          bonus = bonus,
-          isPreSelected = isPreselected,
-          gamificationLevel = gamificationLevel,
-          skuDescription = getSkuDescription(),
-          isSubscription = isSubscription,
-          isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
-          frequency = frequency,
-        )
+    replaceFragment(
+      GooglePayWebFragment.newInstance(
+        paymentType = paymentType,
+        origin = getOrigin(isBds),
+        transactionBuilder = transaction!!,
+        amount = amount,
+        currency = currency,
+        bonus = bonus,
+        isPreSelected = isPreselected,
+        gamificationLevel = gamificationLevel,
+        skuDescription = getSkuDescription(),
+        isSubscription = isSubscription,
+        isSkills = intent.dataString?.contains(SKILLS_TAG) ?: false,
+        frequency = frequency,
       )
-      .commit()
+    )
   }
 
   override fun showMiPayWeb(
@@ -432,19 +362,18 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isBds: Boolean,
     bonus: String?
   ) {
-    val fragmentMiPay = MiPayFragment()
-    fragmentMiPay.arguments = Bundle().apply {
-      putString(MiPayFragment.ORIGIN_KEY, getOrigin(isBds))
-      putParcelable(MiPayFragment.TRANSACTION_DATA_KEY, transaction!!)
-      putSerializable(MiPayFragment.AMOUNT_KEY, amount)
-      putString(MiPayFragment.CURRENCY_KEY, currency)
-      putString(MiPayFragment.BONUS_KEY, bonus)
-    }
-    supportFragmentManager.beginTransaction()
-      .add(R.id.fragment_container, fragmentMiPay)
-      .addToBackStack(MiPayFragment::class.java.simpleName)
-      .commit()
-
+    addFragment(
+      fragment = MiPayFragment().apply {
+        arguments = bundleOf(
+          MiPayFragment.ORIGIN_KEY to getOrigin(isBds),
+          MiPayFragment.TRANSACTION_DATA_KEY to transaction!!,
+          MiPayFragment.AMOUNT_KEY to amount,
+          MiPayFragment.CURRENCY_KEY to currency,
+          MiPayFragment.BONUS_KEY to bonus,
+        )
+      },
+      addToBackStackName = MiPayFragment::class.java.simpleName
+    )
   }
 
   override fun showCarrierBilling(
@@ -453,25 +382,22 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     bonus: BigDecimal?,
     isPreselected: Boolean
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        CarrierVerifyFragment.newInstance(
-          isPreselected,
-          transaction!!.domain,
-          getOrigin(isBds),
-          transaction!!.type,
-          intent.dataString,
-          currency,
-          amount,
-          transaction!!.amount(),
-          bonus,
-          getSkuDescription(),
-          transaction!!.skuId
-        )
-      )
-      .addToBackStack(CarrierVerifyFragment.BACKSTACK_NAME)
-      .commit()
+    replaceFragment(
+      fragment = CarrierVerifyFragment.newInstance(
+        preSelected = isPreselected,
+        domain = transaction!!.domain,
+        origin = getOrigin(isBds),
+        transactionType = transaction!!.type,
+        transactionData = intent.dataString,
+        currency = currency,
+        amount = amount,
+        appcAmount = transaction!!.amount(),
+        bonus = bonus,
+        skuDescription = getSkuDescription(),
+        skuId = transaction!!.skuId
+      ),
+      addToBackStackName = CarrierVerifyFragment.BACKSTACK_NAME
+    )
   }
 
   override fun showAppcoinsCreditsPayment(
@@ -480,18 +406,16 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     gamificationLevel: Int,
     transactionBuilder: TransactionBuilder
   ) {
-    supportFragmentManager.beginTransaction().replace(
-      R.id.fragment_container,
+    replaceFragment(
       AppcoinsRewardsBuyFragment.newInstance(
-        appcAmount,
-        transactionBuilder,
-        intent.data!!.toString(),
-        isBds,
-        isPreselected,
-        gamificationLevel
+        amount = appcAmount,
+        transactionBuilder = transactionBuilder,
+        uri = intent.data!!.toString(),
+        isBds = isBds,
+        isPreSelected = isPreselected,
+        gamificationLevel = gamificationLevel
       )
     )
-      .commit()
   }
 
   override fun showLocalPayment(
@@ -515,32 +439,29 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     gamificationLevel: Int,
     guestWalletId: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        LocalPaymentFragment.newInstance(
-          domain,
-          skuId,
-          originalAmount,
-          currency,
-          bonus,
-          selectedPaymentMethod,
-          developerAddress,
-          type,
-          amount,
-          callbackUrl,
-          orderReference,
-          payload,
-          getOrigin(isBds),
-          paymentMethodIconUrl,
-          paymentMethodLabel,
-          async,
-          referralUrl,
-          gamificationLevel,
-          guestWalletId
-        )
+    replaceFragment(
+      LocalPaymentFragment.newInstance(
+        domain = domain,
+        skudId = skuId,
+        originalAmount = originalAmount,
+        currency = currency,
+        bonus = bonus,
+        selectedPaymentMethod = selectedPaymentMethod,
+        developerAddress = developerAddress,
+        type = type,
+        amount = amount,
+        callbackUrl = callbackUrl,
+        orderReference = orderReference,
+        payload = payload,
+        origin = getOrigin(isBds),
+        paymentMethodIconUrl = paymentMethodIconUrl,
+        paymentMethodLabel = paymentMethodLabel,
+        async = async,
+        referralUrl = referralUrl,
+        gamificationLevel = gamificationLevel,
+        guestWalletId = guestWalletId
       )
-      .commit()
+    )
   }
 
   override fun createChallengeReward(walletAddress: String) =
@@ -563,22 +484,19 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     binding.layoutError.visibility = View.GONE
     binding.fragmentContainer.visibility = View.VISIBLE
 
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        PaymentMethodsFragment.newInstance(
-          transaction,
-          getSkuDescription(),
-          isBds,
-          isDonation,
-          developerPayload,
-          uri,
-          intent.dataString,
-          isSubscription,
-          transaction?.subscriptionPeriod
-        )
+    replaceFragment(
+      PaymentMethodsFragment.newInstance(
+        transaction = transaction,
+        productName = getSkuDescription(),
+        isBds = isBds,
+        isDonation = isDonation,
+        developerPayload = developerPayload,
+        uri = uri,
+        transactionData = intent.dataString,
+        isSubscription = isSubscription,
+        frequency = transaction?.subscriptionPeriod
       )
-      .commit()
+    )
   }
 
   override fun showShareLinkPayment(
@@ -590,20 +508,17 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     type: String,
     selectedPaymentMethod: String
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        SharePaymentLinkFragment.newInstance(
-          domain,
-          skuId,
-          originalAmount,
-          originalCurrency,
-          amount,
-          type,
-          selectedPaymentMethod
-        )
+    replaceFragment(
+      SharePaymentLinkFragment.newInstance(
+        domain = domain,
+        skuId = skuId,
+        originalAmount = originalAmount,
+        originalCurrency = originalCurrency,
+        amount = amount,
+        type = type,
+        paymentMethod = selectedPaymentMethod
       )
-      .commit()
+    )
   }
 
   override fun showMergedAppcoins(
@@ -617,41 +532,54 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     isSubscription: Boolean,
     frequency: String?
   ) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        MergedAppcoinsFragment.newInstance(
-          fiatAmount,
-          currency,
-          bonus,
-          transaction.domain,
-          getSkuDescription(),
-          transaction.amount(),
-          isBds,
-          isDonation,
-          transaction.skuId,
-          transaction.type,
-          gamificationLevel,
-          transaction,
-          isSubscription,
-          frequency
-        )
+    replaceFragment(
+      MergedAppcoinsFragment.newInstance(
+        fiatAmount = fiatAmount,
+        currency = currency,
+        bonus = bonus,
+        appName = transaction.domain,
+        productName = getSkuDescription(),
+        appcAmount = transaction.amount(),
+        isBds = isBds,
+        isDonation = isDonation,
+        skuId = transaction.skuId,
+        transactionType = transaction.type,
+        gamificationLevel = gamificationLevel,
+        transactionBuilder = transaction,
+        isSubscription = isSubscription,
+        frequency = frequency
       )
-      .commit()
+    )
   }
 
   override fun showEarnAppcoins(domain: String, skuId: String?, amount: BigDecimal, type: String) {
-    supportFragmentManager.beginTransaction()
-      .replace(
-        R.id.fragment_container,
-        EarnAppcoinsFragment.newInstance(domain, skuId, amount, type)
+    replaceFragment(
+      EarnAppcoinsFragment.newInstance(
+        domain = domain,
+        skuId = skuId,
+        amount = amount,
+        type = type
       )
-      .commit()
+    )
   }
 
   override fun showUpdateRequiredView() {
+    replaceFragment(IabUpdateRequiredFragment())
+  }
+
+  @SuppressLint("CommitTransaction")
+  private fun addFragment(fragment: Fragment, addToBackStackName: String? = null) {
     supportFragmentManager.beginTransaction()
-      .replace(R.id.fragment_container, IabUpdateRequiredFragment())
+      .add(R.id.fragment_container, fragment)
+      .apply { addToBackStackName?.let { addToBackStack(it) } }
+      .commit()
+  }
+
+  @SuppressLint("CommitTransaction")
+  private fun replaceFragment(fragment: Fragment, addToBackStackName: String? = null) {
+    supportFragmentManager.beginTransaction()
+      .replace(R.id.fragment_container, fragment)
+      .apply { addToBackStackName?.let { addToBackStack(it) } }
       .commit()
   }
 
@@ -701,19 +629,17 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     transaction!!.origin
   }
 
-  private fun createBundle(amount: BigDecimal): Bundle = Bundle().apply {
-    putSerializable(TRANSACTION_AMOUNT, amount)
-    putString(APP_PACKAGE, transaction!!.domain)
-    putString(PRODUCT_NAME, intent.extras!!.getString(PRODUCT_NAME))
-    putString(TRANSACTION_DATA, intent.dataString)
-    putString(DEVELOPER_PAYLOAD, transaction!!.payload)
-  }
-
-  fun isBds() = intent.getBooleanExtra(EXTRA_BDS_IAP, false)
+  private fun createBundle(amount: BigDecimal) = bundleOf(
+    TRANSACTION_AMOUNT to amount,
+    APP_PACKAGE to transaction!!.domain,
+    PRODUCT_NAME to intent.extras!!.getString(PRODUCT_NAME),
+    TRANSACTION_DATA to intent.dataString,
+    DEVELOPER_PAYLOAD to transaction!!.payload,
+  )
 
   override fun navigateToUri(url: String) = navigateToWebViewAuthorization(url)
 
-  override fun uriResults() = results
+  override fun uriResults(): PublishRelay<Uri> = results
 
   override fun launchIntent(intent: Intent) = startActivity(intent)
 
@@ -725,13 +651,13 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   }
 
-  override fun backButtonPress() = backButtonPress!!
+  override fun backButtonPress(): PublishRelay<Any> = backButtonPress
 
   override fun successWebViewResult(data: Uri?) =
-    results!!.accept(Objects.requireNonNull(data, "Intent data cannot be null!"))
+    results.accept(Objects.requireNonNull(data, "Intent data cannot be null!"))
 
   override fun authenticationResult(success: Boolean) {
-    authenticationResultSubject?.onNext(success)
+    authenticationResultSubject.onNext(success)
   }
 
   override fun showTopupFlow() = startActivity(TopUpActivity.newIntent(this))
@@ -741,26 +667,20 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     super.onPause()
   }
 
-  override fun onDestroy() {
-    backButtonPress = null
-    super.onDestroy()
-  }
-
   private fun getSkuDescription(): String = when {
     transaction?.productName.isNullOrEmpty().not() -> transaction?.productName!!
     transaction != null && transaction!!.skuId.isNullOrEmpty().not() -> transaction!!.skuId
     else -> ""
   }
 
+  @Suppress("DEPRECATION")
   override fun showAuthenticationActivity() {
-    val intent = AuthenticationPromptActivity
-      .newIntent(this)
+    val intent = AuthenticationPromptActivity.newIntent(this)
       .apply { intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP }
-    @Suppress("DEPRECATION")
     startActivityForResult(intent, AUTHENTICATION_REQUEST_CODE)
   }
 
-  override fun onAuthenticationResult(): Observable<Boolean> = authenticationResultSubject!!
+  override fun onAuthenticationResult(): Observable<Boolean> = authenticationResultSubject
 
   @Composable
   fun ConnectionAlert(isConnected: Boolean) {
@@ -768,31 +688,27 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
   }
 
   companion object {
-
+    private const val RESULT_USER_CANCELED = 1
+    private const val BDS = "BDS"
+    private const val IS_BDS_EXTRA = "is_bds_extra"
+    private const val ERROR_RECEIVER = "error_receiver"
+    private const val ERROR_RECEIVER_GENERIC = "error_receiver_generic"
+    private const val SKILLS_TAG = "&skills"
     const val BILLING_ADDRESS_REQUEST_CODE = 1236
     const val BILLING_ADDRESS_SUCCESS_CODE = 1000
-    const val BILLING_ADDRESS_CANCEL_CODE = 1001
     const val URI = "uri"
     const val RESPONSE_CODE = "RESPONSE_CODE"
-    const val RESULT_USER_CANCELED = 1
     const val APP_PACKAGE = "app_package"
     const val TRANSACTION_EXTRA = "transaction_extra"
     const val PRODUCT_NAME = "product_name"
-    const val OEMID = "OEMID"
-    const val GUEST_WALLET_ID = "GUEST_WALLET_ID"
     const val TRANSACTION_DATA = "transaction_data"
     const val TRANSACTION_HASH = "transaction_hash"
     const val TRANSACTION_AMOUNT = "transaction_amount"
     const val DEVELOPER_PAYLOAD = "developer_payload"
-    const val BDS = "BDS"
     const val WEB_VIEW_REQUEST_CODE = 1234
     const val BLOCKED_WARNING_REQUEST_CODE = 12345
     const val AUTHENTICATION_REQUEST_CODE = 33
-    const val IS_BDS_EXTRA = "is_bds_extra"
-    const val ERROR_RECEIVER = "error_receiver"
     const val ERROR_RECEIVER_NETWORK = "error_receiver_network"
-    const val ERROR_RECEIVER_GENERIC = "error_receiver_generic"
-    const val SKILLS_TAG = "&skills"
 
     @JvmStatic
     fun newIntent(

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -134,7 +134,7 @@ class IabPresenter(
             context = BillingAnalytics.WALLET_PRESELECTED_PAYMENT_METHOD
           )
         } else {
-          billingAnalytics.sendPurchaseStartWithoutDetailsEvent(
+          billingAnalytics.sendPurchaseStartEvent(
             packageName = transaction?.domain,
             skuDetails = transaction?.skuId,
             value = transaction?.amount().toString(),

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -9,6 +9,8 @@ import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.feature.walletInfo.data.wallet.domain.Wallet
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetShowRefundDisclaimerCodeUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.SetCachedShowRefundDisclaimerUseCase
+import com.asfoundation.wallet.di.NetworkDispatcher
+import com.asfoundation.wallet.di.ViewDispatcher
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.promotions.usecases.StartVipReferralPollingUseCase
 import com.asfoundation.wallet.ui.AuthenticationPromptActivity
@@ -19,11 +21,11 @@ import io.reactivex.Completable
 import io.reactivex.Scheduler
 import io.reactivex.disposables.CompositeDisposable
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
-class IabPresenter(
-  private val view: IabView,
-  private val networkScheduler: Scheduler,
-  private val viewScheduler: Scheduler,
+class IabPresenter @Inject constructor(
+  @NetworkDispatcher private val networkScheduler: Scheduler,
+  @ViewDispatcher private val viewScheduler: Scheduler,
   private val disposable: CompositeDisposable,
   private val billingAnalytics: BillingAnalytics,
   private val iabInteract: IabInteract,
@@ -33,15 +35,23 @@ class IabPresenter(
   private val getShowRefundDisclaimerCodeUseCase: GetShowRefundDisclaimerCodeUseCase,
   private val setCachedShowRefundDisclaimerUseCase: SetCachedShowRefundDisclaimerUseCase,
   private val logger: Logger,
-  private val transaction: TransactionBuilder?,
-  private val errorFromReceiver: String? = null
 ) {
+
+  private lateinit var view: IabView
+  private var transaction: TransactionBuilder? = null
+  private var errorFromReceiver: String? = null
 
   private var firstImpression = true
 
   companion object {
     private val TAG = IabActivity::class.java.name
     private const val FIRST_IMPRESSION = "first_impression"
+  }
+
+  fun init(view: IabView, transaction: TransactionBuilder?, errorFromReceiver: String?) {
+    this.view = view
+    this.transaction = transaction
+    this.errorFromReceiver = errorFromReceiver
   }
 
   fun present(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -38,7 +38,6 @@ class IabPresenter(
 ) {
 
   private var firstImpression = true
-  var webViewResultCode: String? = null
 
   companion object {
     private val TAG = IabActivity::class.java.name
@@ -91,11 +90,6 @@ class IabPresenter(
     )
   }
 
-  private fun handleError(throwable: Throwable) {
-    logger.log(TAG, throwable)
-    view.finishWithError()
-  }
-
   fun handlePerkNotifications(bundle: Bundle) {
     disposable.add(iabInteract.getWalletAddress()
       .subscribeOn(networkScheduler)
@@ -132,17 +126,20 @@ class IabPresenter(
       if (firstImpression) {
         if (iabInteract.hasPreSelectedPaymentMethod()) {
           billingAnalytics.sendPurchaseStartEvent(
-            transaction?.domain, transaction?.skuId,
-            transaction?.amount()
-              .toString(), iabInteract.getPreSelectedPaymentMethod(),
-            transaction?.type, BillingAnalytics.WALLET_PRESELECTED_PAYMENT_METHOD
+            packageName = transaction?.domain,
+            skuDetails = transaction?.skuId,
+            value = transaction?.amount().toString(),
+            purchaseDetails = iabInteract.getPreSelectedPaymentMethod(),
+            transactionType = transaction?.type,
+            context = BillingAnalytics.WALLET_PRESELECTED_PAYMENT_METHOD
           )
         } else {
           billingAnalytics.sendPurchaseStartWithoutDetailsEvent(
-            transaction?.domain,
-            transaction?.skuId, transaction?.amount()
-              .toString(), transaction?.type,
-            BillingAnalytics.WALLET_PAYMENT_METHOD
+            packageName = transaction?.domain,
+            skuDetails = transaction?.skuId,
+            value = transaction?.amount().toString(),
+            transactionType = transaction?.type,
+            context = BillingAnalytics.WALLET_PAYMENT_METHOD
           )
         }
         firstImpression = false

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
@@ -15,9 +15,7 @@ import java.math.BigDecimal
 
 interface IabView {
 
-  fun disableBack()
-
-  fun enableBack()
+  fun setBackEnable(enable: Boolean)
 
   fun finish(bundle: Bundle)
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
@@ -275,7 +275,7 @@ class MergedAppcoinsFragment : BasePageViewFragment(), MergedAppcoinsView {
     setHeaderInformation()
     setButtonsText()
     setBonus()
-    iabView.disableBack()
+    iabView.setBackEnable(false)
     mergedAppcoinsPresenter.present(savedInstanceState)
   }
 
@@ -617,7 +617,7 @@ class MergedAppcoinsFragment : BasePageViewFragment(), MergedAppcoinsView {
 
   override fun onDestroyView() {
     mergedAppcoinsPresenter.handleStop()
-    iabView.enableBack()
+    iabView.setBackEnable(true)
     binding.appcoinsRadio.appcoinsRadioButton.setOnCheckedChangeListener(null)
     binding.appcoinsRadio.root.setOnClickListener(null)
     binding.creditsRadio.creditsRadioButton.setOnCheckedChangeListener(null)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.kt
@@ -444,7 +444,7 @@ class PaymentMethodsFragment : BasePageViewFragment(), PaymentMethodsView {
 
   override fun showItemAlreadyOwnedError() {
     binding.paymentMethodMainView.visibility = View.GONE
-    iabView.disableBack()
+    iabView.setBackEnable(false)
     binding.errorMessage.errorDismiss.setText(getString(R.string.ok))
     binding.errorMessage.root.visibility = View.VISIBLE
     binding.errorMessage.genericErrorLayout.errorMessage.setText(

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/localpayments/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/localpayments/LocalPaymentFragment.kt
@@ -76,7 +76,7 @@ class LocalPaymentFragment : BasePageViewFragment(), LocalPaymentView {
       binding.fragmentIabTransactionCompleted.lottieTransactionSuccess.setAnimation(R.raw.top_up_success_animation)
     }
 
-    iabView.disableBack()
+    iabView.setBackEnable(false)
   }
 
   override fun onViewStateRestored(savedInstanceState: Bundle?) {
@@ -292,7 +292,7 @@ class LocalPaymentFragment : BasePageViewFragment(), LocalPaymentView {
         .alpha(1f)
         .withEndAction {
           this.isClickable = true
-          iabView.enableBack()
+          iabView.setBackEnable(true)
         }
         .setDuration(TimeUnit.SECONDS.toMillis(1))
         .setListener(null)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/carrier/confirm/CarrierFeeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/carrier/confirm/CarrierFeeFragment.kt
@@ -52,7 +52,7 @@ class CarrierFeeFragment : BasePageViewFragment(), CarrierFeeView {
   }
 
   override fun onDestroyView() {
-    iabView.enableBack()
+    iabView.setBackEnable(true)
     presenter.stop()
     super.onDestroyView()
   }
@@ -64,7 +64,7 @@ class CarrierFeeFragment : BasePageViewFragment(), CarrierFeeView {
   }
 
   private fun setupUi() {
-    iabView.disableBack()
+    iabView.setBackEnable(false)
 
     (views.dialogBuyButtonsPaymentMethods?.cancelButton
       ?: views.dialogBuyButtons?.cancelButton)?.run {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/carrier/status/CarrierPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/payments/carrier/status/CarrierPaymentFragment.kt
@@ -43,7 +43,7 @@ class CarrierPaymentFragment : BasePageViewFragment(), CarrierPaymentView {
   }
 
   private fun setupUi() {
-    iabView.disableBack()
+    iabView.setBackEnable(false)
     lockRotation()
 
   }
@@ -83,7 +83,7 @@ class CarrierPaymentFragment : BasePageViewFragment(), CarrierPaymentView {
   }
 
   override fun onDestroyView() {
-    iabView.enableBack()
+    iabView.setBackEnable(true)
     unlockRotation()
     presenter.stop()
     super.onDestroyView()

--- a/app/src/main/java/com/asfoundation/wallet/util/IntentExtensions.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/IntentExtensions.kt
@@ -1,0 +1,12 @@
+package com.asfoundation.wallet.util
+
+import android.content.Intent
+import android.os.Build
+import android.os.Parcelable
+
+@Suppress("DEPRECATION")
+inline fun <reified T : Parcelable> Intent.getParcelable(name: String) =
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+    getParcelableExtra(name, T::class.java)
+  else
+    getParcelableExtra(name)

--- a/app/src/main/res/layout-land/fragment_top_up.xml
+++ b/app/src/main/res/layout-land/fragment_top_up.xml
@@ -37,9 +37,9 @@
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="16dp"
           android:layout_marginTop="16dp"
+          android:animateLayoutChanges="true"
           android:background="@drawable/rectangle_blue_secondary_radius_16dp"
           android:visibility="visible"
-          android:animateLayoutChanges="true"
           app:layout_constraintEnd_toStartOf="@id/mid_guideline"
           app:layout_constraintHorizontal_bias="1.0"
           app:layout_constraintStart_toStartOf="parent"
@@ -151,6 +151,7 @@
             android:layout_marginTop="8dp"
             android:alpha="0.3"
             android:background="@color/styleguide_dark_grey"
+            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/info_fees"
             />
 
@@ -173,6 +174,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="40dp"
             android:layout_marginEnd="16dp"
+            android:importantForAccessibility="no"
             android:src="@drawable/ic_topup_error"
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="@id/main_value"
@@ -180,7 +182,6 @@
             app:layout_constraintHorizontal_bias="1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/main_value"
-            android:importantForAccessibility="no"
             />
 
         <include
@@ -192,7 +193,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="@dimen/big_margin"
             android:layout_marginBottom="8dp"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -292,8 +293,8 @@
           android:id="@+id/tv_refund_disclaimer"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:layout_marginTop="8dp"
           android:layout_marginStart="@dimen/big_margin"
+          android:layout_marginTop="8dp"
           android:layout_marginEnd="@dimen/big_margin"
           android:text="@string/purchase_legal_disclaimer"
           android:textColor="@color/styleguide_dark_grey"

--- a/app/src/main/res/layout/fragment_top_up.xml
+++ b/app/src/main/res/layout/fragment_top_up.xml
@@ -27,9 +27,9 @@
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="16dp"
           android:layout_marginTop="16dp"
+          android:animateLayoutChanges="true"
           android:background="@drawable/rectangle_blue_secondary_radius_16dp"
           android:visibility="visible"
-          android:animateLayoutChanges="true"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintHorizontal_bias="1.0"
           app:layout_constraintStart_toStartOf="parent"
@@ -141,6 +141,7 @@
             android:layout_marginTop="8dp"
             android:alpha="0.3"
             android:background="@color/styleguide_dark_grey"
+            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/info_fees"
             />
 
@@ -182,7 +183,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="@dimen/big_margin"
             android:layout_marginBottom="8dp"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
@@ -18,6 +18,7 @@ class BillingAnalytics @Inject constructor(
   private val appStartPreferencesDataSource: AppStartPreferencesDataSource,
   private val gamesHubContentProviderService: GamesHubContentProviderService,
 ) : EventSender {
+
   override fun sendPurchaseDetailsEvent(
     packageName: String,
     skuDetails: String?,
@@ -25,31 +26,49 @@ class BillingAnalytics @Inject constructor(
     transactionType: String?,
     isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    val purchaseData: MutableMap<String, Any?> = HashMap()
-    purchaseData[EVENT_PACKAGE_NAME] = packageName
-    purchaseData[EVENT_SKU] = skuDetails
-    purchaseData[EVENT_VALUE] = value
-    eventData[EVENT_PURCHASE] = purchaseData
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, PURCHASE_DETAILS, AnalyticsManager.Action.CLICK, WALLET)
+    val purchaseData = mutableMapOf(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_SKU to skuDetails,
+      EVENT_VALUE to value,
+    )
+    val eventData = mutableMapOf(
+      EVENT_PURCHASE to purchaseData,
+      EVENT_TRANSACTION_TYPE to transactionType,
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      PURCHASE_DETAILS,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
   }
 
   override fun sendPaymentMethodDetailsEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String,
+    isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    val purchaseData: MutableMap<String, Any?> = HashMap()
-    purchaseData[EVENT_PACKAGE_NAME] = packageName
-    purchaseData[EVENT_SKU] = skuDetails
-    purchaseData[EVENT_VALUE] = value
-    eventData[EVENT_PURCHASE] = purchaseData
-    eventData[EVENT_PAYMENT_METHOD] = purchaseDetails
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, PAYMENT_METHOD_DETAILS, AnalyticsManager.Action.CLICK, WALLET)
+    val purchaseData = mutableMapOf(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_SKU to skuDetails,
+      EVENT_VALUE to value,
+    )
+    val eventData = mutableMapOf(
+      EVENT_PURCHASE to purchaseData,
+      EVENT_PAYMENT_METHOD to purchaseDetails,
+      EVENT_TRANSACTION_TYPE to transactionType,
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      PAYMENT_METHOD_DETAILS,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
   }
 
   override fun sendActionPaymentMethodDetailsActionEvent(
@@ -62,78 +81,143 @@ class BillingAnalytics @Inject constructor(
     isOnboardingPayment: Boolean
   ) {
     val eventData = createBaseWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails, transactionType,
-      action, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      action = action,
+      isOnboardingPayment = isOnboardingPayment
     )
     analytics.logEvent(
-      eventData, WALLET_PAYMENT_METHOD_DETAILS, AnalyticsManager.Action.CLICK,
+      eventData,
+      WALLET_PAYMENT_METHOD_DETAILS,
+      AnalyticsManager.Action.CLICK,
       WALLET
     )
   }
 
   override fun sendPaymentEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String,
+    isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any> = HashMap()
-    val purchaseData: MutableMap<String, Any> = HashMap()
-    purchaseData[EVENT_PACKAGE_NAME] = packageName
-    skuDetails?.let { purchaseData[EVENT_SKU] = skuDetails }
-    purchaseData[EVENT_VALUE] = value
-    eventData[EVENT_PURCHASE] = purchaseData
-    eventData[EVENT_PAYMENT_METHOD] = purchaseDetails
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, PAYMENT, AnalyticsManager.Action.IMPRESSION, WALLET)
+    val purchaseData = mutableMapOf(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_VALUE to value,
+    ).apply { skuDetails?.let { EVENT_SKU to skuDetails } }
+
+    val eventData = mutableMapOf(
+      EVENT_PURCHASE to purchaseData,
+      EVENT_PAYMENT_METHOD to purchaseDetails,
+      EVENT_TRANSACTION_TYPE to transactionType,
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      PAYMENT,
+      AnalyticsManager.Action.IMPRESSION,
+      WALLET
+    )
   }
 
-  override fun sendRevenueEvent(value: String, isOnboardingPayment: Boolean) {
-    val eventData: MutableMap<String, Any> = HashMap()
-    eventData[EVENT_VALUE] = value
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] =
-      true
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    analytics.logEvent(eventData, REVENUE, AnalyticsManager.Action.IMPRESSION, WALLET)
+  override fun sendRevenueEvent(
+    value: String,
+    isOnboardingPayment: Boolean
+  ) {
+    val eventData = mutableMapOf<String, Any>(
+      EVENT_VALUE to value,
+      EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId(),
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      REVENUE,
+      AnalyticsManager.Action.IMPRESSION,
+      WALLET
+    )
   }
 
   override fun sendPreSelectedPaymentMethodEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String?, action: String, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String?,
+    action: String,
+    isOnboardingPayment: Boolean
   ) {
     val eventData = createBaseWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails, transactionType,
-      action, isOnboardingPayment
-    )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      action = action,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply { EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId() }
+
     analytics.logEvent(
-      eventData, WALLET_PRESELECTED_PAYMENT_METHOD, AnalyticsManager.Action.CLICK,
+      eventData,
+      WALLET_PRESELECTED_PAYMENT_METHOD,
+      AnalyticsManager.Action.CLICK,
       WALLET
     )
   }
 
   override fun sendPaymentMethodEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String?, action: String, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String?,
+    action: String,
+    isOnboardingPayment: Boolean
   ) {
     val eventData = createBaseWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails, transactionType,
-      action, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      action = action,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply { EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId() }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_METHOD,
+      AnalyticsManager.Action.CLICK,
+      WALLET
     )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    analytics.logEvent(eventData, WALLET_PAYMENT_METHOD, AnalyticsManager.Action.CLICK, WALLET)
   }
 
   override fun sendPaymentConfirmationEvent(
-    packageName: String?, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String?, action: String, isOnboardingPayment: Boolean
+    packageName: String?,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String?,
+    action: String,
+    isOnboardingPayment: Boolean
   ) {
     val eventData = createBaseWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails, transactionType,
-      action, isOnboardingPayment
-    )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      action = action,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply { EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId() }
+
     analytics.logEvent(
-      eventData, WALLET_PAYMENT_CONFIRMATION, AnalyticsManager.Action.CLICK,
+      eventData,
+      WALLET_PAYMENT_CONFIRMATION,
+      AnalyticsManager.Action.CLICK,
       WALLET
     )
   }
@@ -148,12 +232,23 @@ class BillingAnalytics @Inject constructor(
     isOnboardingPayment: Boolean
   ) {
     val eventData = createConclusionWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails,
-      transactionType, EVENT_FAIL, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      status = EVENT_FAIL,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply {
+      EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId()
+      EVENT_ERROR_CODE to errorCode
+    }
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_CONCLUSION,
+      AnalyticsManager.Action.CLICK,
+      WALLET
     )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    eventData[EVENT_ERROR_CODE] = errorCode
-    analytics.logEvent(eventData, WALLET_PAYMENT_CONCLUSION, AnalyticsManager.Action.CLICK, WALLET)
   }
 
   override fun sendPaymentErrorWithDetailsEvent(
@@ -167,35 +262,72 @@ class BillingAnalytics @Inject constructor(
     isOnboardingPayment: Boolean
   ) {
     val eventData = createConclusionWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails,
-      transactionType, EVENT_FAIL, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      status = EVENT_FAIL,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply {
+      EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId()
+      EVENT_ERROR_CODE to errorCode
+      EVENT_ERROR_DETAILS to errorDetails
+    }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_CONCLUSION,
+      AnalyticsManager.Action.CLICK,
+      WALLET
     )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    eventData[EVENT_ERROR_CODE] = errorCode
-    eventData[EVENT_ERROR_DETAILS] = errorDetails
-    analytics.logEvent(eventData, WALLET_PAYMENT_CONCLUSION, AnalyticsManager.Action.CLICK, WALLET)
   }
 
   override fun sendPaymentErrorWithDetailsAndRiskEvent(
-    packageName: String, skuDetails: String,
-    value: String, purchaseDetails: String, transactionType: String, errorCode: String,
-    errorDetails: String?, riskRules: String?, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String,
+    errorCode: String,
+    errorDetails: String?,
+    riskRules: String?,
+    isOnboardingPayment: Boolean
   ) {
     val eventData = createConclusionWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails,
-      transactionType, EVENT_FAIL, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      status = EVENT_FAIL,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply {
+      EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId()
+      EVENT_ERROR_CODE to errorCode
+      errorDetails?.let { EVENT_ERROR_DETAILS to it }
+      riskRules?.let { EVENT_CODE_RISK_RULES to it }
+    }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_CONCLUSION,
+      AnalyticsManager.Action.CLICK,
+      WALLET
     )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    eventData[EVENT_ERROR_CODE] = errorCode
-    errorDetails?.let { eventData[EVENT_ERROR_DETAILS] = errorDetails }
-    riskRules?.let { eventData[EVENT_CODE_RISK_RULES] = riskRules }
-    analytics.logEvent(eventData, WALLET_PAYMENT_CONCLUSION, AnalyticsManager.Action.CLICK, WALLET)
   }
 
   override fun sendPaymentSuccessEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String, isOnboardingPayment: Boolean,
-    txId: String, valueUsd: String, isStoredCard: Boolean?, wasCvcRequired: Boolean?,
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String,
+    isOnboardingPayment: Boolean,
+    txId: String,
+    valueUsd: String,
+    isStoredCard: Boolean?,
+    wasCvcRequired: Boolean?,
   ) {
     val eventData: MutableMap<String, Any?> = createConclusionWalletEventMap(
       packageName = packageName,
@@ -217,8 +349,8 @@ class BillingAnalytics @Inject constructor(
     // without contentProvider.
     if (!gamesHubContentProviderService.doesProviderExist()) {
       GamesHubBroadcastService.sendSuccessPaymentBroadcast(
-        context,
-        txId,
+        context = context,
+        uid = txId,
         packageName = packageName,
         usdAmount = valueUsd,
         appcAmount = value
@@ -226,49 +358,89 @@ class BillingAnalytics @Inject constructor(
     }
 
     eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    analytics.logEvent(eventData, WALLET_PAYMENT_CONCLUSION, AnalyticsManager.Action.CLICK, WALLET)
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_CONCLUSION,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
     appStartPreferencesDataSource.saveIsFirstPayment(isFirstPayment = false)
   }
 
   override fun sendPaymentPendingEvent(
-    packageName: String, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String, isOnboardingPayment: Boolean
+    packageName: String,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String,
+    isOnboardingPayment: Boolean
   ) {
     val eventData: MutableMap<String, Any?> = createConclusionWalletEventMap(
-      packageName, skuDetails, value, purchaseDetails,
-      transactionType, EVENT_PENDING, isOnboardingPayment
+      packageName = packageName,
+      skuDetails = skuDetails,
+      value = value,
+      purchaseDetails = purchaseDetails,
+      transactionType = transactionType,
+      status = EVENT_PENDING,
+      isOnboardingPayment = isOnboardingPayment
+    ).apply { EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId() }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_CONCLUSION,
+      AnalyticsManager.Action.CLICK,
+      WALLET
     )
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    analytics.logEvent(eventData, WALLET_PAYMENT_CONCLUSION, AnalyticsManager.Action.CLICK, WALLET)
   }
 
   override fun sendPurchaseStartEvent(
-    packageName: String?, skuDetails: String?, value: String,
-    purchaseDetails: String, transactionType: String?, context: String, isOnboardingPayment: Boolean
+    packageName: String?,
+    skuDetails: String?,
+    value: String,
+    purchaseDetails: String,
+    transactionType: String?,
+    context: String,
+    isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    eventData[EVENT_PACKAGE_NAME] = packageName
-    eventData[EVENT_SKU] = skuDetails
-    eventData[EVENT_VALUE] = value
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    eventData[EVENT_PAYMENT_METHOD] = purchaseDetails
-    eventData[EVENT_CONTEXT] = context
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, WALLET_PAYMENT_START, AnalyticsManager.Action.CLICK, WALLET)
+    val eventData = mutableMapOf<String, Any?>(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_SKU to skuDetails,
+      EVENT_VALUE to value,
+      EVENT_TRANSACTION_TYPE to transactionType,
+      EVENT_PAYMENT_METHOD to purchaseDetails,
+      EVENT_CONTEXT to context,
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_START,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
   }
 
   override fun sendPurchaseStartWithoutDetailsEvent(
-    packageName: String?, skuDetails: String?,
-    value: String, transactionType: String?, context: String, isOnboardingPayment: Boolean
+    packageName: String?,
+    skuDetails: String?,
+    value: String,
+    transactionType: String?,
+    context: String,
+    isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    eventData[EVENT_PACKAGE_NAME] = packageName
-    eventData[EVENT_SKU] = skuDetails
-    eventData[EVENT_VALUE] = value
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    eventData[EVENT_CONTEXT] = context
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, WALLET_PAYMENT_START, AnalyticsManager.Action.CLICK, WALLET)
+    val eventData = mutableMapOf<String, Any?>(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_SKU to skuDetails,
+      EVENT_VALUE to value,
+      EVENT_TRANSACTION_TYPE to transactionType,
+      EVENT_CONTEXT to context,
+    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYMENT_START,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
   }
 
   override fun sendPaypalUrlEvent(
@@ -281,21 +453,29 @@ class BillingAnalytics @Inject constructor(
     url: String?,
     isOnboardingPayment: Boolean
   ) {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    eventData[EVENT_PACKAGE_NAME] = packageName
-    eventData[EVENT_SKU] = skuDetails
-    eventData[EVENT_VALUE] = value
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    eventData[EVENT_PAYPAL_TYPE] = type
-    eventData[EVENT_RESULT_CODE] = resultCode
-    eventData[EVENT_OEMID] = oemIdPreferencesDataSource.getCurrentOemId()
-    if (url?.length!! > MAX_CHARACTERS) {
-      eventData[EVENT_URL] = url.substring(url.length - MAX_CHARACTERS)
-    } else {
-      eventData[EVENT_URL] = url
+    val eventData = mutableMapOf<String, Any?>(
+      EVENT_PACKAGE_NAME to packageName,
+      EVENT_SKU to skuDetails,
+      EVENT_VALUE to value,
+      EVENT_TRANSACTION_TYPE to transactionType,
+      EVENT_PAYPAL_TYPE to type,
+      EVENT_RESULT_CODE to resultCode,
+      EVENT_OEMID to oemIdPreferencesDataSource.getCurrentOemId(),
+    ).apply {
+      EVENT_URL to if (url != null && url.length > MAX_CHARACTERS) {
+        url.substring(url.length - MAX_CHARACTERS)
+      } else {
+        url
+      }
+      if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true
     }
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    analytics.logEvent(eventData, WALLET_PAYPAL_URL, AnalyticsManager.Action.CLICK, WALLET)
+
+    analytics.logEvent(
+      eventData,
+      WALLET_PAYPAL_URL,
+      AnalyticsManager.Action.CLICK,
+      WALLET
+    )
   }
 
   private fun createBaseWalletEventMap(
@@ -306,17 +486,14 @@ class BillingAnalytics @Inject constructor(
     transactionType: String?,
     action: String,
     isOnboardingPayment: Boolean = false
-  ): MutableMap<String, Any?> {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    eventData[EVENT_PACKAGE_NAME] = packageName
-    eventData[EVENT_SKU] = skuDetails
-    eventData[EVENT_VALUE] = value
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    eventData[EVENT_PAYMENT_METHOD] = purchaseDetails
-    eventData[EVENT_ACTION] = action
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    return eventData
-  }
+  ): MutableMap<String, Any?> = mutableMapOf<String, Any?>(
+    EVENT_PACKAGE_NAME to packageName,
+    EVENT_SKU to skuDetails,
+    EVENT_VALUE to value,
+    EVENT_TRANSACTION_TYPE to transactionType,
+    EVENT_PAYMENT_METHOD to purchaseDetails,
+    EVENT_ACTION to action,
+  ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
 
   private fun createConclusionWalletEventMap(
     packageName: String,
@@ -327,18 +504,15 @@ class BillingAnalytics @Inject constructor(
     status: String,
     isOnboardingPayment: Boolean = false,
     cardPaymentType: String? = null,
-  ): MutableMap<String, Any?> {
-    val eventData: MutableMap<String, Any?> = HashMap()
-    eventData[EVENT_PACKAGE_NAME] = packageName
-    eventData[EVENT_SKU] = skuDetails
-    eventData[EVENT_VALUE] = value
-    eventData[EVENT_TRANSACTION_TYPE] = transactionType
-    eventData[EVENT_PAYMENT_METHOD] = purchaseDetails
-    eventData[EVENT_STATUS] = status
-    eventData[EVENT_CARD_PAYMENT_TYPE] = cardPaymentType
-    if (isOnboardingPayment) eventData[EVENT_ONBOARDING_PAYMENT] = true
-    return eventData
-  }
+  ): MutableMap<String, Any?> = mutableMapOf<String, Any?>(
+    EVENT_PACKAGE_NAME to packageName,
+    EVENT_SKU to skuDetails,
+    EVENT_VALUE to value,
+    EVENT_TRANSACTION_TYPE to transactionType,
+    EVENT_PAYMENT_METHOD to purchaseDetails,
+    EVENT_STATUS to status,
+    EVENT_CARD_PAYMENT_TYPE to cardPaymentType,
+  ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
 
   companion object {
     const val PURCHASE_DETAILS = "PURCHASE_DETAILS"

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
@@ -409,7 +409,7 @@ class BillingAnalytics @Inject constructor(
       EVENT_VALUE to value,
       EVENT_TRANSACTION_TYPE to transactionType,
       EVENT_CONTEXT to context,
-      OEM_ID to oemId,
+      EVENT_OEMID to (oemId ?: ""),
     ).apply {
       purchaseDetails?.let { EVENT_PAYMENT_METHOD to it }
       if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true
@@ -527,7 +527,6 @@ class BillingAnalytics @Inject constructor(
     private const val EVENT_TRANSACTION_TYPE = "transaction_type"
     private const val EVENT_PAYMENT_METHOD = "payment_method"
     private const val EVENT_CONTEXT = "context"
-    private const val OEM_ID = "oem_id"
     private const val EVENT_STATUS = "status"
     private const val EVENT_ERROR_CODE = "error_code"
     private const val EVENT_ERROR_DETAILS = "error_details"

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
@@ -397,34 +397,9 @@ class BillingAnalytics @Inject constructor(
     packageName: String?,
     skuDetails: String?,
     value: String,
-    purchaseDetails: String,
     transactionType: String?,
     context: String,
-    isOnboardingPayment: Boolean
-  ) {
-    val eventData = mutableMapOf<String, Any?>(
-      EVENT_PACKAGE_NAME to packageName,
-      EVENT_SKU to skuDetails,
-      EVENT_VALUE to value,
-      EVENT_TRANSACTION_TYPE to transactionType,
-      EVENT_PAYMENT_METHOD to purchaseDetails,
-      EVENT_CONTEXT to context,
-    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
-
-    analytics.logEvent(
-      eventData,
-      WALLET_PAYMENT_START,
-      AnalyticsManager.Action.CLICK,
-      WALLET
-    )
-  }
-
-  override fun sendPurchaseStartWithoutDetailsEvent(
-    packageName: String?,
-    skuDetails: String?,
-    value: String,
-    transactionType: String?,
-    context: String,
+    purchaseDetails: String?,
     isOnboardingPayment: Boolean
   ) {
     val eventData = mutableMapOf<String, Any?>(
@@ -433,7 +408,10 @@ class BillingAnalytics @Inject constructor(
       EVENT_VALUE to value,
       EVENT_TRANSACTION_TYPE to transactionType,
       EVENT_CONTEXT to context,
-    ).apply { if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true }
+    ).apply {
+      purchaseDetails?.let { EVENT_PAYMENT_METHOD to it }
+      if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true
+    }
 
     analytics.logEvent(
       eventData,

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/BillingAnalytics.kt
@@ -399,6 +399,7 @@ class BillingAnalytics @Inject constructor(
     value: String,
     transactionType: String?,
     context: String,
+    oemId: String?,
     purchaseDetails: String?,
     isOnboardingPayment: Boolean
   ) {
@@ -408,6 +409,7 @@ class BillingAnalytics @Inject constructor(
       EVENT_VALUE to value,
       EVENT_TRANSACTION_TYPE to transactionType,
       EVENT_CONTEXT to context,
+      OEM_ID to oemId,
     ).apply {
       purchaseDetails?.let { EVENT_PAYMENT_METHOD to it }
       if (isOnboardingPayment) EVENT_ONBOARDING_PAYMENT to true
@@ -525,6 +527,7 @@ class BillingAnalytics @Inject constructor(
     private const val EVENT_TRANSACTION_TYPE = "transaction_type"
     private const val EVENT_PAYMENT_METHOD = "payment_method"
     private const val EVENT_CONTEXT = "context"
+    private const val OEM_ID = "oem_id"
     private const val EVENT_STATUS = "status"
     private const val EVENT_ERROR_CODE = "error_code"
     private const val EVENT_ERROR_DETAILS = "error_details"

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
@@ -133,6 +133,7 @@ interface EventSender {
     value: String,
     transactionType: String?,
     context: String,
+    oemId: String?,
     purchaseDetails: String? = null,
     isOnboardingPayment: Boolean = false
   )

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
@@ -37,7 +37,10 @@ interface EventSender {
     isOnboardingPayment: Boolean = false
   )
 
-  fun sendRevenueEvent(value: String, isOnboardingPayment: Boolean = false)
+  fun sendRevenueEvent(
+    value: String,
+    isOnboardingPayment: Boolean = false
+  )
 
   fun sendPreSelectedPaymentMethodEvent(
     packageName: String,

--- a/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
+++ b/core/analytics/src/main/java/com/appcoins/wallet/core/analytics/analytics/legacy/EventSender.kt
@@ -131,18 +131,9 @@ interface EventSender {
     packageName: String?,
     skuDetails: String?,
     value: String,
-    purchaseDetails: String,
     transactionType: String?,
     context: String,
-    isOnboardingPayment: Boolean = false
-  )
-
-  fun sendPurchaseStartWithoutDetailsEvent(
-    packageName: String?,
-    skuDetails: String?,
-    value: String,
-    transactionType: String?,
-    context: String,
+    purchaseDetails: String? = null,
     isOnboardingPayment: Boolean = false
   )
 


### PR DESCRIPTION
**What does this PR do?**

   This PR has some code refactored for easier reading. It also adds the oemId to the wallet_payment_start analytic.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] OnboardingPaymentEvents.kt
- [ ] OnboardingPaymentViewModel.kt
- [ ] IabPresenter.kt
- [ ] BillingAnalytics.kt
- [ ] EventSender.kt
- [ ] AdyenPaymentFragment.kt
- [ ] GooglePayWebFragment.kt
- [ ] RxSchedulers.kt
- [ ] LocalPaymentFragment.kt
- [ ] CarrierFeeFragment.kt
- [ ] CarrierPaymentFragment.kt
- [ ] EarnAppcoinsFragment.kt
- [ ] IabActivity.kt
- [ ] IabView.kt
- [ ] MergedAppcoinsFragment.kt
- [ ] PaymentMethodsFragment.kt
- [ ] OneStepPaymentReceiver.kt
- [ ] IntentExtensions.kt

**How should this be manually tested?**

  Flow on how to test this.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4494](https://aptoide.atlassian.net/browse/APPC-4494)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4494]: https://aptoide.atlassian.net/browse/APPC-4494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ