### PR TITLE
[APPC-4001] Promotions get buttons are not visible

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/home/HomeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/HomeFragment.kt
@@ -298,7 +298,12 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
         item { SkeletonLoadingPromotionCards(hasVerticalList = false) }
       } else {
         items(viewModel.activePromotions) { promotion ->
-          PromotionsCardComposable(cardItem = promotion, fragmentName, buttonsAnalytics)
+          PromotionsCardComposable(
+            cardItem = promotion,
+            fragmentName = fragmentName,
+            buttonsAnalytics = buttonsAnalytics,
+            modifier = Modifier.fillParentMaxWidth(0.9f)
+          )
         }
       }
     }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -97,6 +97,7 @@ private fun LoadingPromotionCard() {
 
 @Composable
 fun PromotionsCardComposable(
+  modifier: Modifier = Modifier,
   cardItem: CardPromotionItem,
   fragmentName: String,
   buttonsAnalytics: ButtonsAnalytics?
@@ -104,7 +105,7 @@ fun PromotionsCardComposable(
   var borderColor = Color.Transparent
   var topEndRoundedCornerCard = 16.dp
   val spacerSize = if (cardItem.hasVerticalList) 8.dp else 16.dp
-  Column {
+  Column(modifier = modifier) {
     if (cardItem.hasVipPromotion) {
       // Set Changes in VIP Cards
       borderColor = WalletColors.styleguide_vip_yellow


### PR DESCRIPTION
**What does this PR do?**

   Fix misplaced "Get" button on promotions card

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HomeFragment.kt
- [ ] PromotionsCardComposable.kt

**How should this be manually tested?**

  Check home screen and see the promotions card. "Get" button should be right aligned.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4001](https://aptoide.atlassian.net/browse/APPC-4001)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4001]: https://aptoide.atlassian.net/browse/APPC-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ