### PR TITLE
[APPC-4564] Adjust rewards partner's header

### DIFF
--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsActionsComposable.kt
@@ -48,6 +48,7 @@ fun RewardsActions(
     modifier = Modifier
       .horizontalScroll(scrollState)
       .padding(horizontal = 16.dp)
+      .padding(top = 16.dp)
       .height(IntrinsicSize.Max),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
   ) {
@@ -143,7 +144,7 @@ fun SkeletonLoadingRewardsActionsCard() {
     modifier = Modifier
       .horizontalScroll(scrollState)
       .padding(horizontal = 16.dp)
-      .padding(top = 24.dp),
+      .padding(top = 16.dp),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     SkeletonLoadingRewardActionCard()

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/RewardsGamificationComposable.kt
@@ -292,7 +292,8 @@ fun GamificationHeaderNoPurchases() {
 fun GamificationHeaderPartner(bonusPerkDescription: String) {
   Card(
     modifier = Modifier
-      .padding(16.dp)
+      .padding(horizontal = 16.dp)
+      .padding(top = 16.dp)
       .fillMaxWidth(),
     shape = RoundedCornerShape(8.dp),
     colors = CardDefaults.cardColors(WalletColors.styleguide_blue_secondary),


### PR DESCRIPTION
**What does this PR do?**

   Adjust rewards partner's header

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RewardsActionsComposable.kt
- [ ] RewardsGamificationComposable.kt

**How should this be manually tested?**

  Test Rewards screen on partner and aptoide states and validate the screen's header paddings.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4564](https://aptoide.atlassian.net/browse/APPC-4564)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
