### PR TITLE
[APPC-4669] Promo code deeplink error if no wallet created

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
@@ -126,6 +126,9 @@ class MainActivity : AppCompatActivity(),
     }
   }
 
+  private fun launchedFromPromoCodeOrGiftCard() =
+    intent.action == Intent.ACTION_VIEW && (intent.data?.host == BuildConfig.GIFT_CARD_HOST || intent.data?.host == BuildConfig.PROMO_CODE_HOST)
+
   override fun onStateChanged(state: MainActivityState) = Unit
 
   override fun onSideEffect(sideEffect: MainActivitySideEffect) {
@@ -136,14 +139,21 @@ class MainActivity : AppCompatActivity(),
       MainActivitySideEffect.NavigateToFingerprintAuthentication ->
         navigator.showAuthenticationActivity(this, authenticationResultLauncher)
 
-      MainActivitySideEffect.NavigateToOnboarding ->
-        navigator.navigateToOnboarding(navController)
+      MainActivitySideEffect.NavigateToOnboarding -> {
+        navigator.navigateToOnboarding(
+          navController = navController,
+          createWalletAutomatically = launchedFromPromoCodeOrGiftCard()
+        )
+      }
 
-      is MainActivitySideEffect.NavigateToOnboardingRecoverGuestWallet ->
+      is MainActivitySideEffect.NavigateToOnboardingRecoverGuestWallet -> {
+        val launchedFromPromoCodeOrGiftCard = launchedFromPromoCodeOrGiftCard()
         navigator.navigateToOnboardingRecoverGuestWallet(
           navController = navController,
           backupModel = sideEffect.backupModel,
+          createWalletAutomatically = launchedFromPromoCodeOrGiftCard
         )
+      }
 
       MainActivitySideEffect.NavigateToNavigationBar ->
         navigator.navigateToNavBarFragment(navController)

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivity.kt
@@ -12,11 +12,13 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.appcoins.wallet.core.arch.SingleStateFragment
 import com.appcoins.wallet.core.utils.android_common.NetworkMonitor
+import com.appcoins.wallet.core.utils.android_common.OnNewIntentActivityHandler
 import com.appcoins.wallet.core.utils.jvm_common.RxBus
 import com.asf.wallet.BuildConfig
 import com.asf.wallet.R
 import com.asfoundation.wallet.main.nav_bar.NavBarFragment
 import com.asfoundation.wallet.main.splash.bus.SplashFinishEvent
+import com.asfoundation.wallet.onboarding.OnboardingFragment
 import com.asfoundation.wallet.onboarding_new_payment.payment_result.SdkPaymentWebSocketListener
 import com.asfoundation.wallet.onboarding_new_payment.payment_result.SdkPaymentWebSocketListener.Companion.SDK_STATUS_SUCCESS
 import com.asfoundation.wallet.support.SupportNotificationProperties.SUPPORT_NOTIFICATION_CLICK
@@ -32,7 +34,7 @@ import javax.inject.Inject
  * Container activity for main screen with bottom navigation (Home, Promotions, My Wallets, Top up)
  */
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(),
+class MainActivity : AppCompatActivity(), OnNewIntentActivityHandler,
   SingleStateFragment<MainActivityState, MainActivitySideEffect> {
 
   @Inject
@@ -47,6 +49,8 @@ class MainActivity : AppCompatActivity(),
   private lateinit var authenticationResultLauncher: ActivityResultLauncher<Intent>
 
   private var disposable: Disposable? = null
+
+  private var newIntent: Intent? = null
 
   /**
   To avoid having to set the theme back to the main app one, we should use the new splash screen api.
@@ -90,16 +94,18 @@ class MainActivity : AppCompatActivity(),
 
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
-    handleInitialNavigation(intent = intent)
+    newIntent = intent
+    handleInitialNavigation(intent = intent, newIntent = true)
   }
 
   private fun handleInitialNavigation(
     authComplete: Boolean = false,
-    intent: Intent? = null,
-    fromSplashScreen: Boolean = false
+    intent: Intent,
+    fromSplashScreen: Boolean = false,
+    newIntent: Boolean = false,
   ) {
-    val action = intent?.action
-    val launchedFromHistory = intent?.flags?.and(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0
+    val action = intent.action
+    val launchedFromHistory = intent.flags.and(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0
 
     if (action == Intent.ACTION_VIEW && launchedFromHistory) {
       val host = intent.data?.host
@@ -108,14 +114,16 @@ class MainActivity : AppCompatActivity(),
           viewModel.handleInitialNavigation(
             authComplete = authComplete,
             giftCard = intent.data?.getQueryParameter(DEEPLINK_GIFT_CARD_QUERY_PARAM),
-            fromSplashScreen = fromSplashScreen
+            fromSplashScreen = fromSplashScreen,
+            newIntent = newIntent,
           )
 
         BuildConfig.PROMO_CODE_HOST ->
           viewModel.handleInitialNavigation(
             authComplete = authComplete,
             promoCode = intent.data?.getQueryParameter(DEEPLINK_PROMO_CODE_QUERY_PARAM),
-            fromSplashScreen = fromSplashScreen
+            fromSplashScreen = fromSplashScreen,
+            newIntent = newIntent,
           )
 
         else ->
@@ -161,8 +169,10 @@ class MainActivity : AppCompatActivity(),
       MainActivitySideEffect.NavigateToPayPalVerification ->
         navigator.navigateToPayPalVerificationFragment(navController)
 
-      is MainActivitySideEffect.NavigateToGiftCard -> {
-        if (navController.currentDestination?.id == R.id.nav_bar_fragment) {
+      is MainActivitySideEffect.NavigateToGiftCard ->
+        if (navController.currentDestination?.id == R.id.nav_bar_fragment ||
+          navController.currentDestination?.id == R.id.onboarding_fragment
+        ) {
           setGiftCardToCurrentFragment(sideEffect.giftCard)
         } else {
           if (sideEffect.fromSplashScreen) {
@@ -177,40 +187,53 @@ class MainActivity : AppCompatActivity(),
             )
           }
         }
-      }
 
-      is MainActivitySideEffect.NavigateToPromoCode -> if (navController.currentDestination?.id == R.id.nav_bar_fragment) {
-        setPromoCodeToCurrentFragment(sideEffect.promoCode)
-      } else {
-        if (sideEffect.fromSplashScreen) {
-          navigator.navigateToPromoCodeFromSplashScreen(
-            navController = navController,
-            promoCode = sideEffect.promoCode
-          )
+      is MainActivitySideEffect.NavigateToPromoCode ->
+        if (navController.currentDestination?.id == R.id.nav_bar_fragment ||
+          navController.currentDestination?.id == R.id.onboarding_fragment
+        ) {
+          setPromoCodeToCurrentFragment(sideEffect.promoCode)
         } else {
-          navigator.navigateToPromoCode(
-            navController = navController,
-            promoCode = sideEffect.promoCode
-          )
+          if (sideEffect.fromSplashScreen) {
+            navigator.navigateToPromoCodeFromSplashScreen(
+              navController = navController,
+              promoCode = sideEffect.promoCode
+            )
+          } else {
+            navigator.navigateToPromoCode(
+              navController = navController,
+              promoCode = sideEffect.promoCode
+            )
+          }
         }
-      }
     }
   }
 
   private fun setGiftCardToCurrentFragment(giftCard: String) {
-    (supportFragmentManager.findFragmentById(R.id.main_host_container)
+    val fragment = (supportFragmentManager.findFragmentById(R.id.main_host_container)
       ?.childFragmentManager
       ?.fragments
-      ?.last() as? NavBarFragment
-        )?.handleGiftCard(giftCard)
+      ?.last())
+
+    when (fragment) {
+      is NavBarFragment -> fragment.handleGiftCard(giftCard)
+      is OnboardingFragment -> fragment.createWalletAutomatically()
+    }
   }
 
+  override fun getCurrentIntent(): Intent =
+    newIntent ?: super.getIntent()
+
   private fun setPromoCodeToCurrentFragment(promoCode: String) {
-    (supportFragmentManager.findFragmentById(R.id.main_host_container)
+    val fragment = (supportFragmentManager.findFragmentById(R.id.main_host_container)
       ?.childFragmentManager
       ?.fragments
-      ?.last() as? NavBarFragment
-        )?.handlePromoCode(promoCode)
+      ?.last())
+
+    when (fragment) {
+      is NavBarFragment -> fragment.handlePromoCode(promoCode)
+      is OnboardingFragment -> fragment.createWalletAutomatically()
+    }
   }
 
   override fun onDestroy() {

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivityNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivityNavigator.kt
@@ -19,17 +19,29 @@ import javax.inject.Inject
 class MainActivityNavigator @Inject constructor() :
   Navigator {
 
-  fun navigateToOnboarding(navController: NavController) {
-    navigate(navController, SplashExtenderFragmentDirections.actionNavigateToOnboardingGraph())
+  fun navigateToOnboarding(
+    navController: NavController,
+    createWalletAutomatically: Boolean
+  ) {
+    navigate(
+      navController = navController,
+      destination = SplashExtenderFragmentDirections.actionNavigateToOnboardingGraph(
+        createWalletAutomatically = createWalletAutomatically
+      )
+    )
   }
 
   fun navigateToOnboardingRecoverGuestWallet(
     navController: NavController,
     backupModel: BackupModel,
+    createWalletAutomatically: Boolean
   ) {
     navController.setGraph(
       graphResId = R.navigation.onboarding_graph,
-      startDestinationArgs = OnboardingFragmentArgs(backupModel = backupModel).toBundle()
+      startDestinationArgs = OnboardingFragmentArgs(
+        backupModel = backupModel,
+        createWalletAutomatically = createWalletAutomatically
+      ).toBundle()
     )
   }
 
@@ -73,7 +85,10 @@ class MainActivityNavigator @Inject constructor() :
   fun navigateToPromoCodeFromSplashScreen(navController: NavController, promoCode: String) {
     navigate(
       navController,
-      SplashExtenderFragmentDirections.actionNavigateToNavBarGraph(giftCard = null, promoCode = promoCode),
+      SplashExtenderFragmentDirections.actionNavigateToNavBarGraph(
+        giftCard = null,
+        promoCode = promoCode
+      ),
     )
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/main/MainActivityViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/MainActivityViewModel.kt
@@ -53,20 +53,26 @@ class MainActivityViewModel @Inject constructor(
     handleSavedStateParameters()
   }
 
-  fun handleInitialNavigation(authComplete: Boolean = false, giftCard: String? = null, promoCode: String? = null, fromSplashScreen: Boolean = false) {
+  fun handleInitialNavigation(
+    authComplete: Boolean = false,
+    giftCard: String? = null,
+    promoCode: String? = null,
+    fromSplashScreen: Boolean = false,
+    newIntent: Boolean = false,
+  ) {
     getAutoUpdateModelUseCase()
       .subscribeOn(rxSchedulers.io)
       .observeOn(rxSchedulers.main)
       .doOnSuccess { (updateVersionCode, updateMinSdk, blackList) ->
         when {
-          hasRequiredHardUpdateUseCase(blackList, updateVersionCode, updateMinSdk) ->
+          !newIntent && hasRequiredHardUpdateUseCase(blackList, updateVersionCode, updateMinSdk) ->
             sendSideEffect { MainActivitySideEffect.NavigateToAutoUpdate }
 
-          hasAuthenticationPermissionUseCase() && !authComplete -> {
+          !newIntent && hasAuthenticationPermissionUseCase() && !authComplete -> {
             sendSideEffect { MainActivitySideEffect.NavigateToFingerprintAuthentication }
           }
 
-          shouldShowOnboardingUseCase() -> {
+          !newIntent && shouldShowOnboardingUseCase() -> {
             getCachedGuestWalletUseCase()
               .subscribeOn(rxSchedulers.io)
               .observeOn(rxSchedulers.main)

--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
@@ -102,9 +102,11 @@ class NavBarFragment : BasePageViewFragment(), SingleStateFragment<NavBarState, 
     views.composeView.setContent { BottomNavigationHome() }
     arguments?.getString(EXTRA_GIFT_CARD)?.let {
       handleGiftCard(it)
+      arguments?.remove(EXTRA_GIFT_CARD)
     }
     arguments?.getString(EXTRA_PROMO_CODE)?.let {
       handlePromoCode(it)
+      arguments?.remove(EXTRA_PROMO_CODE)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragment.kt
@@ -260,7 +260,10 @@ class NavBarFragment : BasePageViewFragment(), SingleStateFragment<NavBarState, 
 
   private fun showOnboardingRecoverGuestWallet() {
     views.fullHostContainer.visibility = View.VISIBLE
-    navigator.showOnboardingRecoverGuestWallet(mainHostFragment.navController)
+    navigator.showOnboardingRecoverGuestWallet(
+      navController = mainHostFragment.navController,
+      createWalletAutomatically = false
+    )
   }
 
   private fun adjustBottomNavigationViewOnKeyboardVisibility() {
@@ -276,6 +279,7 @@ class NavBarFragment : BasePageViewFragment(), SingleStateFragment<NavBarState, 
           views.composeView.visibility = View.VISIBLE
         }
       } catch (e: Exception) {
+        e.printStackTrace()
       }
     }
     views.root.viewTreeObserver?.addOnGlobalLayoutListener(keyboardListener)

--- a/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragmentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/main/nav_bar/NavBarFragmentNavigator.kt
@@ -21,7 +21,11 @@ class NavBarFragmentNavigator @Inject constructor() : Navigator {
     )
   }
 
-  fun navigateToRewards(navController: NavController, giftCard: String? = null, promoCode: String? = null) {
+  fun navigateToRewards(
+    navController: NavController,
+    giftCard: String? = null,
+    promoCode: String? = null
+  ) {
     navController.navigate(
       resId = R.id.reward_graph,
       args = getBundle(giftCard, promoCode),
@@ -48,7 +52,15 @@ class NavBarFragmentNavigator @Inject constructor() : Navigator {
     navigate(navController, NavBarGraphDirections.actionNavigateToFirstPaymentFragment())
   }
 
-  fun showOnboardingRecoverGuestWallet(navController: NavController) {
-    navigate(navController, SplashExtenderFragmentDirections.actionNavigateToOnboardingGraph())
+  fun showOnboardingRecoverGuestWallet(
+    navController: NavController,
+    createWalletAutomatically: Boolean
+  ) {
+    navigate(
+      navController = navController,
+      destination = SplashExtenderFragmentDirections.actionNavigateToOnboardingGraph(
+        createWalletAutomatically = createWalletAutomatically
+      )
+    )
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/create_wallet/CreateWalletDialogFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/create_wallet/CreateWalletDialogFragment.kt
@@ -2,7 +2,6 @@ package com.asfoundation.wallet.my_wallets.create_wallet
 
 import android.animation.Animator
 import android.app.Dialog
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -80,13 +79,13 @@ class CreateWalletDialogFragment : DialogFragment(),
           if (requireArguments().getBoolean(IS_PAYMENT))
             navigator.navigateBack()
           else
-            restart(requireContext())
+            restart()
 
         } else {
           views.createWalletLoading.addAnimatorListener(object : Animator.AnimatorListener {
             override fun onAnimationRepeat(animation: Animator) = Unit
             override fun onAnimationEnd(animation: Animator) = run {
-              restart(requireContext())
+              restart()
             }
 
             override fun onAnimationCancel(animation: Animator) = Unit
@@ -101,9 +100,12 @@ class CreateWalletDialogFragment : DialogFragment(),
     }
   }
 
-  private fun restart(context: Context) {
+  private fun restart() {
     lifecycleScope.launch {
-      AppUtils.restartApp(context)
+      AppUtils.restartApp(
+        activity = requireActivity(),
+        copyIntent = true
+      )
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/BackupModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/BackupModel.kt
@@ -8,7 +8,10 @@ data class BackupModel(
   val backupPrivateKey: String = "",
   val flow: String = "",
   val paymentFunnel: String? = null
-) : Parcelable
+) : Parcelable {
+
+  fun isForRecoverWallet() = backupPrivateKey != "" && flow != "" && paymentFunnel != null
+}
 
 enum class OnboardingFlow {
   VERIFY_PAYPAL,

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -1,6 +1,5 @@
 package com.asfoundation.wallet.onboarding
 
-import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Typeface
 import android.net.Uri
@@ -153,7 +152,7 @@ class OnboardingFragment : BasePageViewFragment(),
 
       OnboardingSideEffect.NavigateToFinish -> {
         unlockRotation()
-        context?.let { restart(it) }
+        restart()
       }
 
       is OnboardingSideEffect.NavigateToLink ->
@@ -173,9 +172,9 @@ class OnboardingFragment : BasePageViewFragment(),
     }
   }
 
-  private fun restart(context: Context) {
+  private fun restart() {
     lifecycleScope.launch {
-      AppUtils.restartApp(context)
+      AppUtils.restartApp(requireActivity())
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -181,7 +181,7 @@ class OnboardingFragment : BasePageViewFragment(),
 
   private fun restart() {
     lifecycleScope.launch {
-      AppUtils.restartApp(requireActivity())
+      AppUtils.restartApp(requireActivity(), copyIntent = createWalletAutomatically)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -65,11 +65,7 @@ class OnboardingFragment : BasePageViewFragment(),
     handleBackPress()
     lockRotation()
     if (createWalletAutomatically) {
-      if (!backupModel.isForRecoverWallet()) {
-        viewModel.handleLaunchWalletClick()
-      } else {
-        viewModel.handleRecoverAndVerifyGuestWalletClick(backupModel)
-      }
+      createWalletAutomatically()
     }
   }
 
@@ -319,6 +315,14 @@ class OnboardingFragment : BasePageViewFragment(),
 
   fun unlockRotation() {
     requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+  }
+
+  fun createWalletAutomatically() {
+    if (!backupModel.isForRecoverWallet()) {
+      viewModel.handleLaunchWalletClick()
+    } else {
+      viewModel.handleRecoverAndVerifyGuestWalletClick(backupModel)
+    }
   }
 
 }

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingFragment.kt
@@ -48,6 +48,7 @@ class OnboardingFragment : BasePageViewFragment(),
   private val args by navArgs<OnboardingFragmentArgs>()
 
   private val backupModel by lazy { args.backupModel ?: BackupModel() }
+  private val createWalletAutomatically by lazy { args.createWalletAutomatically }
 
   private val viewModel: OnboardingViewModel by viewModels()
   private val views by viewBinding(FragmentOnboardingBinding::bind)
@@ -63,6 +64,13 @@ class OnboardingFragment : BasePageViewFragment(),
     super.onCreate(savedInstanceState)
     handleBackPress()
     lockRotation()
+    if (createWalletAutomatically) {
+      if (!backupModel.isForRecoverWallet()) {
+        viewModel.handleLaunchWalletClick()
+      } else {
+        viewModel.handleRecoverAndVerifyGuestWalletClick(backupModel)
+      }
+    }
   }
 
   override fun onResume() {
@@ -82,7 +90,6 @@ class OnboardingFragment : BasePageViewFragment(),
     }
   }
 
-
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -98,8 +105,12 @@ class OnboardingFragment : BasePageViewFragment(),
   }
 
   private fun setClickListeners() {
-    views.onboardingButtons.onboardingNextButton.setOnClickListener { viewModel.handleLaunchWalletClick() }
-    views.onboardingButtons.onboardingExistentWalletButton.setOnClickListener { viewModel.handleRecoverClick() }
+    views.onboardingButtons.onboardingNextButton.setOnClickListener {
+      viewModel.handleLaunchWalletClick()
+    }
+    views.onboardingButtons.onboardingExistentWalletButton.setOnClickListener {
+      viewModel.handleRecoverClick()
+    }
     views.onboardingRecoverGuestButton.setOnClickListener {
       viewModel.handleRecoverAndVerifyGuestWalletClick(backupModel)
     }

--- a/app/src/main/java/com/asfoundation/wallet/onboarding/pending_payment/OnboardingPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/pending_payment/OnboardingPaymentFragment.kt
@@ -86,7 +86,7 @@ class OnboardingPaymentFragment : BasePageViewFragment(),
       views.root.visibility = View.GONE
       context?.let {
         lifecycleScope.launch {
-          AppUtils.restartApp(it)
+          AppUtils.restartApp(requireActivity())
         }
       }
     }

--- a/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/recover/success/RecoveryWalletSuccessBottomSheetFragment.kt
@@ -1,14 +1,10 @@
 package com.asfoundation.wallet.recover.success
 
-
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.appcoins.wallet.core.arch.SideEffect
 import com.appcoins.wallet.core.arch.SingleStateFragment
@@ -58,7 +54,7 @@ class RecoveryWalletSuccessBottomSheetFragment : BottomSheetDialogFragment(),
 
     views.recoveryWalletBottomButton.setOnClickListener {
       if (requireArguments().getBoolean(IS_FROM_ONBOARDING)) {
-        restart(requireContext())
+        restart()
       } else {
         navigator.navigateBack()
         dismiss()
@@ -66,9 +62,12 @@ class RecoveryWalletSuccessBottomSheetFragment : BottomSheetDialogFragment(),
     }
   }
 
-  private fun restart(context: Context) {
+  private fun restart() {
     lifecycleScope.launch {
-      AppUtils.restartApp(context)
+      AppUtils.restartApp(
+        activity = requireActivity(),
+        copyIntent = true
+      )
     }
   }
 
@@ -86,10 +85,4 @@ class RecoveryWalletSuccessBottomSheetFragment : BottomSheetDialogFragment(),
 
   override fun onSideEffect(sideEffect: SideEffect) = Unit
 
-  private fun navController(): NavController {
-    val navHostFragment =
-      requireActivity().supportFragmentManager.findFragmentById(R.id.main_host_container)
-          as NavHostFragment
-    return navHostFragment.navController
-  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_reward/RewardFragment.kt
@@ -126,9 +126,11 @@ class RewardFragment : BasePageViewFragment(), SingleStateFragment<RewardState, 
     viewModel.updateNotificationBadge()
     arguments?.getString(EXTRA_GIFT_CARD)?.let {
       navigator.showGiftCardFragment(it)
+      arguments?.remove(EXTRA_GIFT_CARD)
     }
     arguments?.getString(EXTRA_PROMO_CODE)?.let {
       navigator.showPromoCodeFragment(it)
+      arguments?.remove(EXTRA_PROMO_CODE)
     }
   }
 

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -29,7 +29,14 @@
         android:id="@+id/action_navigate_to_onboarding_graph"
         app:destination="@id/onboarding_graph"
         app:popUpTo="@id/splash_extender_fragment"
-        app:popUpToInclusive="true" />
+        app:popUpToInclusive="true" >
+
+      <argument
+          android:name="createWalletAutomatically"
+          app:nullable="false"
+          app:argType="boolean" />
+
+    </action>
     <action
         android:id="@+id/action_navigate_to_update_required_graph"
         app:destination="@id/update_required_graph"

--- a/app/src/main/res/navigation/onboarding_graph.xml
+++ b/app/src/main/res/navigation/onboarding_graph.xml
@@ -11,6 +11,11 @@
       tools:layout="@layout/fragment_onboarding">
 
     <argument
+        android:name="createWalletAutomatically"
+        app:nullable="false"
+        app:argType="boolean" />
+
+    <argument
         android:name="backupModel"
         app:nullable="true"
         android:defaultValue="@null"

--- a/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/AppUtils.kt
+++ b/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/AppUtils.kt
@@ -1,20 +1,25 @@
 package com.appcoins.wallet.core.utils.android_common
 
-import android.content.Context
+import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import kotlinx.coroutines.delay
 
 class AppUtils {
   companion object {
-    suspend fun restartApp(context: Context) {
+    suspend fun restartApp(activity: Activity, copyIntent: Boolean = false) {
       delay(100)
-      val packageManager: PackageManager = context.packageManager
-      val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+      val packageManager: PackageManager = activity.packageManager
+      val intent = packageManager.getLaunchIntentForPackage(activity.packageName)
       val componentName = intent!!.component
       val mainIntent = Intent.makeRestartActivityTask(componentName)
-      mainIntent.setPackage(context.packageName)
-      context.startActivity(mainIntent)
+      mainIntent.setPackage(activity.packageName)
+      if (copyIntent) {
+        mainIntent.data = activity.intent.data
+        mainIntent.action = activity.intent.action
+        activity.intent.extras?.let { mainIntent.putExtras(it) }
+      }
+      activity.startActivity(mainIntent)
       Runtime.getRuntime().exit(0)
     }
   }

--- a/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/AppUtils.kt
+++ b/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/AppUtils.kt
@@ -5,22 +5,22 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import kotlinx.coroutines.delay
 
-class AppUtils {
-  companion object {
-    suspend fun restartApp(activity: Activity, copyIntent: Boolean = false) {
-      delay(100)
-      val packageManager: PackageManager = activity.packageManager
-      val intent = packageManager.getLaunchIntentForPackage(activity.packageName)
-      val componentName = intent!!.component
-      val mainIntent = Intent.makeRestartActivityTask(componentName)
-      mainIntent.setPackage(activity.packageName)
-      if (copyIntent) {
-        mainIntent.data = activity.intent.data
-        mainIntent.action = activity.intent.action
-        activity.intent.extras?.let { mainIntent.putExtras(it) }
-      }
-      activity.startActivity(mainIntent)
-      Runtime.getRuntime().exit(0)
+object AppUtils {
+  suspend fun restartApp(activity: Activity, copyIntent: Boolean = false) {
+    delay(100)
+    val packageManager: PackageManager = activity.packageManager
+    val intent = packageManager.getLaunchIntentForPackage(activity.packageName)
+    val componentName = intent!!.component
+    val mainIntent = Intent.makeRestartActivityTask(componentName)
+    mainIntent.setPackage(activity.packageName)
+    if (copyIntent) {
+      val copiedIntent =
+        if (activity is OnNewIntentActivityHandler) activity.getCurrentIntent() else activity.intent
+      mainIntent.data = copiedIntent.data
+      mainIntent.action = copiedIntent.action
+      activity.intent.extras?.let { mainIntent.putExtras(it) }
     }
+    activity.startActivity(mainIntent)
+    Runtime.getRuntime().exit(0)
   }
 }

--- a/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/OnNewIntentActivityHandler.kt
+++ b/core/utils/android-common/src/main/java/com/appcoins/wallet/core/utils/android_common/OnNewIntentActivityHandler.kt
@@ -1,0 +1,7 @@
+package com.appcoins.wallet.core.utils.android_common
+
+import android.content.Intent
+
+interface OnNewIntentActivityHandler {
+  fun getCurrentIntent(): Intent
+}


### PR DESCRIPTION
**What does this PR do?**

   There was an issue when the app was launched from a promocode or giftcard and there was no wallet created. In this scenario the promocode/giftcard screens were not showing up with the data. Fix this issue by recovering the intent on restart. The onboarding is not recovering the intent because if the onboarding is appearing, its because the app was not started from a promocode/giftcard deeplink

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] CreateWalletDialogFragment.kt
- [ ] OnboardingPaymentFragment.kt
- [ ] OnboardingFragment.kt
- [ ] RecoveryWalletSuccessBottomSheetFragment.kt

**How should this be manually tested?**

  Launch the app using a deeplink with a promocode or giftcard. validate that the promocode or giftcard screens appear.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4669](https://aptoide.atlassian.net/browse/APPC-4669)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4669]: https://aptoide.atlassian.net/browse/APPC-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ