### PR TITLE
[APPC-4706] Adyen sdk update adjust fraud object validation

### DIFF
--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/AdyenApi.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/AdyenApi.kt
@@ -7,7 +7,7 @@ import retrofit2.http.*
 
 interface AdyenApi {
 
-  @POST("8.20240524/gateways/adyen_v2/transactions")
+  @POST("8.20241204/gateways/adyen_v2/transactions")
   fun makeAdyenPayment(
     @Query("wallet.address") walletAddress: String,
     @Header("authorization") authorization: String,

--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/AdyenApi.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/AdyenApi.kt
@@ -6,13 +6,6 @@ import io.reactivex.Single
 import retrofit2.http.*
 
 interface AdyenApi {
-  @POST("8.20240524/gateways/adyen_v2/transactions")
-  @Headers("Content-Type: application/json;format=product_token")
-  fun makeAdyenBodyPayment(
-    @Query("wallet.address") walletAddress: String,
-    @Header("authorization") authorization: String,
-    @Body payment: PaymentRequest
-  ): Single<AdyenTransactionResponse>
 
   @POST("8.20240524/gateways/adyen_v2/transactions")
   fun makeAdyenPayment(

--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/model/FraudResult.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/model/FraudResult.kt
@@ -2,4 +2,4 @@ package com.appcoins.wallet.core.network.microservices.model
 
 import com.google.gson.annotations.SerializedName
 
-data class FraudResult(@SerializedName("FraudCheckResult") val fraudCheckResult: FraudCheckResult)
+data class FraudResult(@SerializedName("FraudCheckResult") val fraudCheckResult: FraudCheckResult?)

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/adyen/AdyenResponseMapper.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/adyen/AdyenResponseMapper.kt
@@ -4,7 +4,16 @@ import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.model.payments.response.Action
 import com.appcoins.wallet.billing.ErrorInfo
-import com.appcoins.wallet.billing.adyen.PaymentModel.Status.*
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.CANCELED
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.COMPLETED
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.FAILED
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.FRAUD
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.INVALID_TRANSACTION
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.PENDING
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.PENDING_SERVICE_AUTHORIZATION
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.PENDING_USER_PAYMENT
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.PROCESSING
+import com.appcoins.wallet.billing.adyen.PaymentModel.Status.SETTLED
 import com.appcoins.wallet.billing.common.BillingErrorMapper
 import com.appcoins.wallet.billing.util.Error
 import com.appcoins.wallet.billing.util.getErrorCodeAndMessage
@@ -37,11 +46,23 @@ open class AdyenResponseMapper @Inject constructor(
       adyenSerializer.deserializePaymentMethods(response)
     return adyenResponse.storedPaymentMethods
       ?.find { it.type == method.adyenType }
-      ?.let { PaymentInfoModel(it, response.adyenPrice.value, response.adyenPrice.currency) }
+      ?.let {
+        PaymentInfoModel(
+          paymentMethod = it,
+          value = response.adyenPrice.value,
+          currency = response.adyenPrice.currency
+        )
+      }
       ?: adyenResponse.paymentMethods
         ?.find { it.type == method.adyenType }
-        ?.let { PaymentInfoModel(it, response.adyenPrice.value, response.adyenPrice.currency) }
-      ?: PaymentInfoModel(Error(true))
+        ?.let {
+          PaymentInfoModel(
+            paymentMethod = it,
+            value = response.adyenPrice.value,
+            currency = response.adyenPrice.currency
+          )
+        }
+      ?: PaymentInfoModel(error = Error(hasError = true))
   }
 
   open fun mapWithFilterByCard(
@@ -53,11 +74,23 @@ open class AdyenResponseMapper @Inject constructor(
       adyenSerializer.deserializePaymentMethods(response)
     return adyenResponse.storedPaymentMethods
       ?.find { it.type == method.adyenType && it.id == cardId }
-      ?.let { PaymentInfoModel(it, response.adyenPrice.value, response.adyenPrice.currency) }
+      ?.let {
+        PaymentInfoModel(
+          paymentMethod = it,
+          value = response.adyenPrice.value,
+          currency = response.adyenPrice.currency
+        )
+      }
       ?: adyenResponse.paymentMethods
         ?.find { it.type == method.adyenType }
-        ?.let { PaymentInfoModel(it, response.adyenPrice.value, response.adyenPrice.currency) }
-      ?: PaymentInfoModel(Error(true))
+        ?.let {
+          PaymentInfoModel(
+            paymentMethod = it,
+            value = response.adyenPrice.value,
+            currency = response.adyenPrice.currency
+          )
+        }
+      ?: PaymentInfoModel(error = Error(hasError = true))
   }
 
   open fun mapWithoutStoredCard(
@@ -68,8 +101,14 @@ open class AdyenResponseMapper @Inject constructor(
       adyenSerializer.deserializePaymentMethods(response)
     return adyenResponse.paymentMethods
       ?.find { it.type == method.adyenType }
-      ?.let { PaymentInfoModel(it, response.adyenPrice.value, response.adyenPrice.currency) }
-      ?: PaymentInfoModel(Error(true))
+      ?.let {
+        PaymentInfoModel(
+          paymentMethod = it,
+          value = response.adyenPrice.value,
+          currency = response.adyenPrice.currency
+        )
+      }
+      ?: PaymentInfoModel(error = Error(hasError = true))
   }
 
   open fun map(response: AdyenTransactionResponse): PaymentModel {
@@ -97,21 +136,39 @@ open class AdyenResponseMapper @Inject constructor(
           redirectUrl = action.url
         }
 
-        THREEDS2 -> action = adyenSerializer.deserialize3DS(jsonAction)
-        THREEDS2FINGERPRINT -> action = adyenSerializer.deserialize3DSFingerprint(jsonAction)
-        THREEDS2CHALLENGE -> action = adyenSerializer.deserialize3DSChallenge(jsonAction)
+        THREEDS2 ->
+          action = adyenSerializer.deserialize3DS(jsonAction)
+
+        THREEDS2FINGERPRINT ->
+          action = adyenSerializer.deserialize3DSFingerprint(jsonAction)
+
+        THREEDS2CHALLENGE ->
+          action = adyenSerializer.deserialize3DSChallenge(jsonAction)
       }
     }
     return PaymentModel(
-      adyenResponse?.resultCode, adyenResponse?.refusalReason,
-      adyenResponse?.refusalReasonCode?.toInt(), action, redirectUrl, action?.paymentData,
-      response.uid, response.metadata?.purchaseUid, response.hash, response.orderReference, fraudResultsId,
-      map(response.status), response.metadata?.errorMessage, response.metadata?.errorCode
+      resultCode = adyenResponse?.resultCode,
+      refusalReason = adyenResponse?.refusalReason,
+      refusalCode = adyenResponse?.refusalReasonCode?.toInt(),
+      action = action,
+      redirectUrl = redirectUrl,
+      paymentData = action?.paymentData,
+      uid = response.uid,
+      purchaseUid = response.metadata?.purchaseUid,
+      hash = response.hash,
+      orderReference = response.orderReference,
+      fraudResultIds = fraudResultsId,
+      status = map(response.status),
+      errorMessage = response.metadata?.errorMessage,
+      errorCode = response.metadata?.errorCode
     )
   }
 
   open fun map(response: TransactionResponse): PaymentModel {
-    return PaymentModel(response, map(response.status))
+    return PaymentModel(
+      response = response,
+      status = map(response.status)
+    )
   }
 
   private fun map(status: TransactionStatus): PaymentModel.Status {
@@ -135,8 +192,18 @@ open class AdyenResponseMapper @Inject constructor(
 
   open fun map(response: Transaction): PaymentModel {
     return PaymentModel(
-      "", null, null, null, "", "", response.uid, response.metadata?.purchaseUid,
-      response.hash, response.orderReference, emptyList(), map(response.status)
+      resultCode = "",
+      refusalReason = null,
+      refusalCode = null,
+      action = null,
+      redirectUrl = "",
+      paymentData = "",
+      uid = response.uid,
+      purchaseUid = response.metadata?.purchaseUid,
+      hash = response.hash,
+      orderReference = response.orderReference,
+      fraudResultIds = emptyList(),
+      status = map(response.status)
     )
   }
 
@@ -158,17 +225,31 @@ open class AdyenResponseMapper @Inject constructor(
   open fun mapInfoModelError(throwable: Throwable): PaymentInfoModel {
     throwable.printStackTrace()
     val codeAndMessage = throwable.getErrorCodeAndMessage()
-    val errorInfo = billingErrorMapper.mapErrorInfo(codeAndMessage.first, codeAndMessage.second)
+    val errorInfo = billingErrorMapper.mapErrorInfo(
+      httpCode = codeAndMessage.first,
+      message = codeAndMessage.second
+    )
     return PaymentInfoModel(
-      Error(true, throwable.isNoNetworkException(), errorInfo)
+      Error(
+        hasError = true,
+        isNetworkError = throwable.isNoNetworkException(),
+        errorInfo = errorInfo
+      )
     )
   }
 
   open fun mapPaymentModelError(throwable: Throwable): PaymentModel {
     throwable.printStackTrace()
     val codeAndMessage = throwable.getErrorCodeAndMessage()
-    val errorInfo = billingErrorMapper.mapErrorInfo(codeAndMessage.first, codeAndMessage.second)
-    val error = Error(true, throwable.isNoNetworkException(), errorInfo)
+    val errorInfo = billingErrorMapper.mapErrorInfo(
+      httpCode = codeAndMessage.first,
+      message = codeAndMessage.second
+    )
+    val error = Error(
+      hasError = true,
+      isNetworkError = throwable.isNoNetworkException(),
+      errorInfo = errorInfo
+    )
     return PaymentModel(error)
   }
 
@@ -176,7 +257,10 @@ open class AdyenResponseMapper @Inject constructor(
     adyenTransactionResponse: AdyenTransactionResponse? = null
   ): VerificationPaymentModel {
     val redirectUrl = adyenTransactionResponse?.let { response -> map(response).redirectUrl }
-    return VerificationPaymentModel(success = true, redirectUrl = redirectUrl)
+    return VerificationPaymentModel(
+      success = true,
+      redirectUrl = redirectUrl
+    )
   }
 
   open fun mapVerificationPaymentModelError(throwable: Throwable): VerificationPaymentModel {
@@ -187,21 +271,37 @@ open class AdyenResponseMapper @Inject constructor(
         gson.fromJson(body, VerificationTransactionResponse::class.java)
       var errorType = VerificationPaymentModel.ErrorType.OTHER
       when (verificationTransactionResponse.code) {
-        "Request.Invalid" -> errorType = VerificationPaymentModel.ErrorType.INVALID_REQUEST
-        "Request.TooMany" -> errorType = VerificationPaymentModel.ErrorType.TOO_MANY_ATTEMPTS
+        "Request.Invalid" ->
+          errorType = VerificationPaymentModel.ErrorType.INVALID_REQUEST
+
+        "Request.TooMany" ->
+          errorType = VerificationPaymentModel.ErrorType.TOO_MANY_ATTEMPTS
       }
       VerificationPaymentModel(
-        false, errorType,
-        verificationTransactionResponse.data?.refusalReason,
-        verificationTransactionResponse.data?.refusalReasonCode?.toInt(), null,
-        Error(hasError = true, isNetworkError = false)
+        success = false,
+        errorType = errorType,
+        refusalReason = verificationTransactionResponse.data?.refusalReason,
+        refusalCode = verificationTransactionResponse.data?.refusalReasonCode?.toInt(),
+        redirectUrl = null,
+        error = Error(
+          hasError = true,
+          isNetworkError = false
+        )
       )
     } else {
       val codeAndMessage = throwable.getErrorCodeAndMessage()
       val errorInfo = billingErrorMapper.mapErrorInfo(codeAndMessage.first, codeAndMessage.second)
       VerificationPaymentModel(
-        false, VerificationPaymentModel.ErrorType.OTHER, null, null,
-        null, Error(true, throwable.isNoNetworkException(), errorInfo)
+        success = false,
+        errorType = VerificationPaymentModel.ErrorType.OTHER,
+        refusalReason = null,
+        refusalCode = null,
+        redirectUrl = null,
+        error = Error(
+          hasError = true,
+          isNetworkError = throwable.isNoNetworkException(),
+          errorInfo = errorInfo
+        )
       )
     }
   }
@@ -214,14 +314,20 @@ open class AdyenResponseMapper @Inject constructor(
         gson.fromJson(body, VerificationErrorResponse::class.java)
       var errorType = VerificationCodeResult.ErrorType.OTHER
       when (verificationTransactionResponse.code) {
-        "Body.Invalid" -> errorType = VerificationCodeResult.ErrorType.WRONG_CODE
-        "Request.TooMany" -> errorType = VerificationCodeResult.ErrorType.TOO_MANY_ATTEMPTS
+        "Body.Invalid" ->
+          errorType = VerificationCodeResult.ErrorType.WRONG_CODE
+
+        "Request.TooMany" ->
+          errorType = VerificationCodeResult.ErrorType.TOO_MANY_ATTEMPTS
       }
       val errorInfo = billingErrorMapper.mapErrorInfo(throwable.code(), body)
       return VerificationCodeResult(
-        false, errorType, Error(
+        success = false,
+        errorType = errorType,
+        error = Error(
           hasError = true,
-          isNetworkError = throwable.isNoNetworkException(), errorInfo = errorInfo
+          isNetworkError = throwable.isNoNetworkException(),
+          errorInfo = errorInfo
         )
       )
     }
@@ -229,8 +335,11 @@ open class AdyenResponseMapper @Inject constructor(
       success = false,
       errorType = VerificationCodeResult.ErrorType.OTHER,
       error = Error(
-        hasError = true, isNetworkError = throwable.isNoNetworkException(),
-        errorInfo = ErrorInfo(text = throwable.message)
+        hasError = true,
+        isNetworkError = throwable.isNoNetworkException(),
+        errorInfo = ErrorInfo(
+          text = throwable.message
+        )
       )
     )
   }
@@ -243,7 +352,7 @@ open class AdyenResponseMapper @Inject constructor(
     val cardsList = adyenResponse.storedPaymentMethods?.filter {
       it.type == AdyenPaymentRepository.Methods.CREDIT_CARD.adyenType
     }
-    return cardsList ?: listOf<StoredPaymentMethod>()
+    return cardsList ?: listOf()
   }
 
   companion object {

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/adyen/AdyenResponseMapper.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/adyen/AdyenResponseMapper.kt
@@ -120,8 +120,10 @@ open class AdyenResponseMapper @Inject constructor(
     var fraudResultsId: List<Int> = emptyList()
 
     if (adyenResponse != null) {
-      if (adyenResponse.fraudResult != null) {
-        fraudResultsId = adyenResponse.fraudResult!!.results.map { it.fraudCheckResult.checkId }
+      if (response.status == TransactionStatus.FAILED && adyenResponse.refusalReason == "FRAUD") {
+        fraudResultsId = adyenResponse.fraudResult?.results
+          ?.mapNotNull { it.fraudCheckResult?.checkId }
+          ?: emptyList()
       }
       if (adyenResponse.action != null) {
         actionType = adyenResponse.action!!.get("type")?.asString


### PR DESCRIPTION
**What does this PR do?**

   Adjusts fraud object validation and bumps the api version

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AdyenApi.kt
- [ ] FraudResult.kt
- [ ] AdyenResponseMapper.kt

**How should this be manually tested?**

  Try a payment with fraud. Validate that it appears the fraud screen and also the success is working correctly.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-4706](https://aptoide.atlassian.net/browse/APPC-4706)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-4706]: https://aptoide.atlassian.net/browse/APPC-4706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ