### PR TITLE
[APPC 5033] Wallet Login | Add wallet address to url

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingAnalytics.kt
+++ b/app/src/main/java/com/asfoundation/wallet/onboarding/OnboardingAnalytics.kt
@@ -9,7 +9,7 @@ class OnboardingAnalytics @Inject constructor(private val analyticsManager: Anal
     private const val WALLET = "WALLET"
     const val WALLET_ONBOARDING_RECOVER_WEB = "wallet_onboarding_recover_web"
     const val BONUS = "bonus"
-    const val BONUS_CURRENCY = "bonus_curency"
+    const val BONUS_CURRENCY = "bonus_currency"
   }
 
   fun sendRecoverGuestWalletEvent(bonus: String, bonusCurrency: String) {


### PR DESCRIPTION
**What does this PR do?**
Adds the address query parameter to login URL.

Update to `GenerateWebLoginUrlUseCase` class:

- `GetCurrentWalletUseCase` dependency has been added to have access to wallet's address.
- `invoke` function has been updated to add address query parameter to URL. This implementation was made using `zip` method from `RxJava`. Combining the asynchronous result of `getCurrentWalletUseCase()` and `getEncryptedPrivateKeyUseCase()`.

Minor Change:
Change on Google Analytics dimensions: bonus_curency -> bonus_currency.

**Database changed?**
No

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5033](https://aptoide.atlassian.net/browse/APPC-5033)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5033]: https://aptoide.atlassian.net/browse/APPC-5033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ