### PR TITLE
[APPC-5044] New Endpoint for Currency

### DIFF
--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/TokenToLocalFiatApi.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/TokenToLocalFiatApi.kt
@@ -21,6 +21,9 @@ interface TokenToLocalFiatApi {
     targetCurrency: String
   ): Single<ConversionResponseBody>
 
+  @GET("8.20180518/wallet/currency")
+  fun getValueToLocalFiat(): Single<ConversionResponseBody>
+
   @GET("8.20180518/exchanges/{currency}/convert/{value}?to=APPC")
   fun convertFiatToAppc(
     @Path("currency") currency: String,

--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/TokenToLocalFiatApi.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/api/broker/TokenToLocalFiatApi.kt
@@ -1,6 +1,7 @@
 package com.appcoins.wallet.core.network.microservices.api.broker
 
 import com.appcoins.wallet.core.network.microservices.model.ConversionResponseBody
+import com.appcoins.wallet.core.network.microservices.model.ConversionWithNoValueResponseBody
 import io.reactivex.Single
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -22,7 +23,7 @@ interface TokenToLocalFiatApi {
   ): Single<ConversionResponseBody>
 
   @GET("8.20180518/wallet/currency")
-  fun getValueToLocalFiat(): Single<ConversionResponseBody>
+  fun getValueToLocalFiat(): Single<ConversionWithNoValueResponseBody>
 
   @GET("8.20180518/exchanges/{currency}/convert/{value}?to=APPC")
   fun convertFiatToAppc(

--- a/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/model/ConversionWithNoValueResponseBody.kt
+++ b/core/network/microservices/src/main/java/com/appcoins/wallet/core/network/microservices/model/ConversionWithNoValueResponseBody.kt
@@ -1,0 +1,7 @@
+package com.appcoins.wallet.core.network.microservices.model
+
+data class ConversionWithNoValueResponseBody(
+  val currency: String,
+  val label: String,
+  val sign: String
+)

--- a/feature/change-currency/data/src/main/java/com/appcoins/wallet/feature/changecurrency/data/currencies/LocalCurrencyConversionService.kt
+++ b/feature/change-currency/data/src/main/java/com/appcoins/wallet/feature/changecurrency/data/currencies/LocalCurrencyConversionService.kt
@@ -11,8 +11,35 @@ class LocalCurrencyConversionService @Inject constructor(
   private val currencyConversionRatesPersistence: CurrencyConversionRatesPersistence
 ) {
 
+  companion object {
+    const val LOCAL_CURRENCY_DEFAULT_AMOUNT = 0.01
+    const val LOCAL_CURRENCY_SCALE = 18
+    const val LOCAL_CURRENCY_APPC_VALUE = "1.0"
+  }
+
   val localCurrency: Single<FiatValue>
-    get() = getAppcToLocalFiat("1.0", 18)
+    get() =
+      tokenToLocalFiatApi
+        .getValueToLocalFiat()
+        .map { localFiatResponse: ConversionResponseBody ->
+          FiatValue(
+            amount = LOCAL_CURRENCY_DEFAULT_AMOUNT.toBigDecimal()
+              .setScale(LOCAL_CURRENCY_SCALE, RoundingMode.FLOOR),
+            currency = localFiatResponse.currency,
+            symbol = localFiatResponse.sign
+          )
+        }
+        .flatMap { fiatValue: FiatValue ->
+          currencyConversionRatesPersistence.saveRateFromAppcToFiat(
+            appcValue = LOCAL_CURRENCY_APPC_VALUE, fiatValue = fiatValue.amount.toString(),
+            fiatCurrency = fiatValue.currency, fiatSymbol = fiatValue.symbol
+          )
+            .andThen(Single.just(fiatValue))
+            .onErrorReturn { throwable: Throwable ->
+              throwable.printStackTrace()
+              fiatValue
+            }
+        }
 
   fun getAppcToLocalFiat(
     value: String, scale: Int,

--- a/feature/change-currency/data/src/main/java/com/appcoins/wallet/feature/changecurrency/data/currencies/LocalCurrencyConversionService.kt
+++ b/feature/change-currency/data/src/main/java/com/appcoins/wallet/feature/changecurrency/data/currencies/LocalCurrencyConversionService.kt
@@ -2,6 +2,7 @@ package com.appcoins.wallet.feature.changecurrency.data.currencies
 
 import com.appcoins.wallet.core.network.microservices.api.broker.TokenToLocalFiatApi
 import com.appcoins.wallet.core.network.microservices.model.ConversionResponseBody
+import com.appcoins.wallet.core.network.microservices.model.ConversionWithNoValueResponseBody
 import io.reactivex.Single
 import java.math.RoundingMode
 import javax.inject.Inject
@@ -21,7 +22,7 @@ class LocalCurrencyConversionService @Inject constructor(
     get() =
       tokenToLocalFiatApi
         .getValueToLocalFiat()
-        .map { localFiatResponse: ConversionResponseBody ->
+        .map { localFiatResponse: ConversionWithNoValueResponseBody ->
           FiatValue(
             amount = LOCAL_CURRENCY_DEFAULT_AMOUNT.toBigDecimal()
               .setScale(LOCAL_CURRENCY_SCALE, RoundingMode.FLOOR),


### PR DESCRIPTION
**What does this PR do?**
   Implements a new endpoint for fetching the user's local currency.

  The `LocalCurrencyConversionService` class has been updated to support the new feature. The value `localCurrency` getter has been updated to call the new endpoint while the rest of the application maintains the old endpoint usage. (`getValueToTargetFiat`).

**Database changed?**

   No

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5044](https://aptoide.atlassian.net/browse/APPC-5044)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5044]: https://aptoide.atlassian.net/browse/APPC-5044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ