### PR TITLE
[APPC-5049] processed value returner return value

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/App.kt
+++ b/app/src/main/java/com/asfoundation/wallet/App.kt
@@ -262,6 +262,8 @@ class App : MultiDexApplication(), BillingDependenciesProvider {
 
   override fun proxyService() = proxyService
 
+  override fun getInjectLogger(): Logger = logger
+
   override fun billingMessagesMapper() = billingMessagesMapper
 
   override fun subscriptionsApi() = subscriptionBillingApi

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
@@ -85,7 +85,7 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
       val enabled = activityInfo.enabled && activityInfo.applicationInfo != null && activityInfo.applicationInfo.enabled
 
       var hasRequiredPerm = true
-      if (activityInfo.permission != null && !activityInfo.permission.isEmpty()) {
+      if (!activityInfo.permission.isNullOrEmpty()) {
         hasRequiredPerm = (pm.checkPermission(
           activityInfo.permission,
           ctx.packageName

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
@@ -25,12 +25,14 @@ import com.appcoins.wallet.bdsbilling.repository.SubscriptionsMapper
 import com.appcoins.wallet.bdsbilling.repository.entity.Product
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.core.network.microservices.model.BillingSupportedType
+import com.appcoins.wallet.core.utils.jvm_common.Logger
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
+
 
 class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
   companion object {
@@ -54,6 +56,10 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
   private lateinit var proxyService: ProxyService
   private lateinit var intentBuilder: BillingIntentBuilder
 
+  private val logger: Logger by lazy {
+    (applicationContext as BillingDependenciesProvider).getInjectLogger()
+  }
+
   private val initializationComplete = CompletableDeferred<Unit>()
 
   @SuppressLint("QueryPermissionsNeeded")
@@ -71,17 +77,17 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
 
     if (matches.isEmpty()) return false
 
-    for (ai in matches) {
-      if (ai == null) continue
-      if (packageName != ai.packageName) continue
+    for (activityInfo in matches) {
+      if (activityInfo == null) continue
+      if (packageName != activityInfo.packageName) continue
 
-      val exported = ai.exported
-      val enabled = ai.enabled && ai.applicationInfo != null && ai.applicationInfo.enabled
+      val exported = activityInfo.exported
+      val enabled = activityInfo.enabled && activityInfo.applicationInfo != null && activityInfo.applicationInfo.enabled
 
       var hasRequiredPerm = true
-      if (ai.permission != null && !ai.permission.isEmpty()) {
+      if (activityInfo.permission != null && !activityInfo.permission.isEmpty()) {
         hasRequiredPerm = (pm.checkPermission(
-          ai.permission,
+          activityInfo.permission,
           ctx.packageName
         ) == PackageManager.PERMISSION_GRANTED)
       }
@@ -100,7 +106,11 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
         senderUri = intent?.getStringExtra(REQUESTER_ACTIVITY_URI)
       )
     ) {
-      Log.e(TAG, "Calling activity is not allowed to bind to the service")
+      logger.log(
+        TAG,
+        "Request activity URI (${intent?.getStringExtra(REQUESTER_ACTIVITY_URI)}) is not marked as exported",
+        asError = true
+      )
       finish()
       return
     }

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
@@ -1,10 +1,15 @@
 package com.appcoins.wallet.billing
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Looper
 import android.os.Parcelable
 import android.util.Log
 import android.view.WindowManager
+import androidx.core.net.toUri
 import com.appcoins.communication.MessageProcessorActivity
 import com.appcoins.wallet.bdsbilling.BdsBilling
 import com.appcoins.wallet.bdsbilling.Billing
@@ -51,7 +56,56 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
 
   private val initializationComplete = CompletableDeferred<Unit>()
 
+  @SuppressLint("QueryPermissionsNeeded")
+  private fun resolveExposedActivity(
+    ctx: Context,
+    packageName: String,
+    senderUri: String?
+  ): Boolean {
+    val probe = Intent(Intent.ACTION_VIEW, senderUri?.toUri())
+    probe.setPackage(packageName)
+
+    val pm = ctx.packageManager
+    val matches = pm.queryIntentActivities(probe, PackageManager.MATCH_ALL)
+
+    if (matches.isEmpty()) return false
+
+    for (ri in matches) {
+      val ai = ri.activityInfo
+      if (ai == null) continue
+      // Must be in the requested package (query should already restrict, but be defensive)
+      if (packageName != ai.packageName) continue
+
+      val exported = ai.exported
+      val enabled = ai.enabled && ai.applicationInfo != null && ai.applicationInfo.enabled
+
+      // If the activity enforces a permission, ensure we hold it
+      var hasRequiredPerm = true
+      if (ai.permission != null && !ai.permission.isEmpty()) {
+        hasRequiredPerm = (pm.checkPermission(
+          ai.permission,
+          ctx.packageName
+        ) == PackageManager.PERMISSION_GRANTED)
+      }
+
+      if (exported && enabled && hasRequiredPerm) {
+        return true
+      }
+    }
+    return false
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
+    if (!resolveExposedActivity(
+        ctx = this,
+        packageName = intent?.getStringExtra(REQUESTER_PACKAGE_NAME) ?: "",
+        senderUri = intent?.getStringExtra(REQUESTER_ACTIVITY_URI)
+      )
+    ) {
+      Log.e(TAG, "Calling activity is not allowed to bind to the service")
+      finish()
+      return
+    }
     super.onCreate(savedInstanceState)
     moveTaskToBack(true)
     if (applicationContext !is BillingDependenciesProvider) {

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
@@ -57,29 +57,27 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
   private val initializationComplete = CompletableDeferred<Unit>()
 
   @SuppressLint("QueryPermissionsNeeded")
-  private fun resolveExposedActivity(
+  private fun checkExposedActivity(
     ctx: Context,
     packageName: String,
     senderUri: String?
   ): Boolean {
     val probe = Intent(Intent.ACTION_VIEW, senderUri?.toUri())
-    probe.setPackage(packageName)
 
     val pm = ctx.packageManager
-    val matches = pm.queryIntentActivities(probe, PackageManager.MATCH_ALL)
+    val matches = pm
+      .queryIntentActivities(probe, PackageManager.MATCH_DEFAULT_ONLY)
+      .map { it.activityInfo }
 
     if (matches.isEmpty()) return false
 
-    for (ri in matches) {
-      val ai = ri.activityInfo
+    for (ai in matches) {
       if (ai == null) continue
-      // Must be in the requested package (query should already restrict, but be defensive)
       if (packageName != ai.packageName) continue
 
       val exported = ai.exported
       val enabled = ai.enabled && ai.applicationInfo != null && ai.applicationInfo.enabled
 
-      // If the activity enforces a permission, ensure we hold it
       var hasRequiredPerm = true
       if (ai.permission != null && !ai.permission.isEmpty()) {
         hasRequiredPerm = (pm.checkPermission(
@@ -96,7 +94,7 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    if (!resolveExposedActivity(
+    if (!checkExposedActivity(
         ctx = this,
         packageName = intent?.getStringExtra(REQUESTER_PACKAGE_NAME) ?: "",
         senderUri = intent?.getStringExtra(REQUESTER_ACTIVITY_URI)

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingReceiverActivity.kt
@@ -100,15 +100,17 @@ class AppcoinsBillingReceiverActivity : MessageProcessorActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    val requesterPackageName = intent?.getStringExtra(REQUESTER_PACKAGE_NAME) ?: ""
+    val requesterActivityUri = intent?.getStringExtra(REQUESTER_ACTIVITY_URI)
     if (!checkExposedActivity(
         ctx = this,
-        packageName = intent?.getStringExtra(REQUESTER_PACKAGE_NAME) ?: "",
-        senderUri = intent?.getStringExtra(REQUESTER_ACTIVITY_URI)
+        packageName = requesterPackageName,
+        senderUri = requesterActivityUri
       )
     ) {
       logger.log(
         TAG,
-        "Request activity URI (${intent?.getStringExtra(REQUESTER_ACTIVITY_URI)}) is not marked as exported",
+        "Request activity URI (${requesterActivityUri}) is not marked as exported",
         asError = true
       )
       finish()

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/BillingDependenciesProvider.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/BillingDependenciesProvider.kt
@@ -7,6 +7,7 @@ import com.appcoins.wallet.core.network.microservices.api.broker.BrokerBdsApi
 import com.appcoins.wallet.core.network.microservices.api.product.InappBillingApi
 import com.appcoins.wallet.core.network.microservices.api.product.SubscriptionBillingApi
 import com.appcoins.wallet.core.utils.android_common.RxSchedulers
+import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.core.walletservices.WalletService
 import com.appcoins.wallet.sharedpreferences.FiatCurrenciesPreferencesDataSource
 
@@ -26,6 +27,8 @@ interface BillingDependenciesProvider {
   fun subscriptionsApi(): SubscriptionBillingApi
 
   fun rxSchedulers(): RxSchedulers
+
+  fun getInjectLogger(): Logger
 
   fun ewtObtainer(): EwtAuthenticatorService
 

--- a/legacy/billing/src/main/java/com/appcoins/wallet/billing/util/ExtensionFunctionUtils.kt
+++ b/legacy/billing/src/main/java/com/appcoins/wallet/billing/util/ExtensionFunctionUtils.kt
@@ -8,7 +8,6 @@ import java.io.IOException
  * Class file to create kotlin extension functions
  *
  */
-
 fun Throwable?.isNoNetworkException(): Boolean {
   return this != null && (this is IOException || this.cause != null && this.cause is IOException)
 }


### PR DESCRIPTION
**What does this PR do?**

   Resolves the issue of communicating with an Activity exposed as false.

   An update has been made in `AppcoinsBillingReceiverActivity` to verify is the billing request is possible (if the activity expressed in REQUESTER_ACTIVITY_URI is marked as exposed or not) before attempting to communicate with the activity, avoiding a `java.lang.SecurityException: Permission Denial`.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppcoinsBillingReceiverActivity.kt
- [ ] MessageProcessorActivity.java (for context purposes)
- [ ] ProcessedValueReturner.java (for context purposes)
- [ ] BillingDependenciesProvider.kt
- [ ] App.kt

**How should this be manually tested?**

  A deeplink should be called with the `adb` using the following format:

```
adb shell am start -a android.intent.action.VIEW \
  -d "appcoins://billing/communication/processor/1" \
  --es REQUESTER_PACKAGE_NAME "THE_PACKAGE_NAME_TO_BE_USED_IN_THE_TEST" \
  --es REQUESTER_ACTIVITY_URI "THE_DEEPLINK_TO_BE_USED_IN_THE_TEST"
```

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5049](https://aptoide.atlassian.net/browse/APPC-5049)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5049]: https://aptoide.atlassian.net/browse/APPC-5049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ