### PR TITLE
[APPC-5107] Log in | Remove Wallet Backup

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/home/HomeViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/HomeViewModel.kt
@@ -360,7 +360,7 @@ constructor(
       .flatMap { observeRefreshData() }
       .switchMap {
         observeWalletInfoUseCase(null, update = true)
-          .map { walletInfo -> walletInfo.hasBackup }
+          .map { walletInfo -> walletInfo.hasBackup || walletInfo.email != null }
           .asAsyncToState(HomeState::hasBackup) { copy(hasBackup = it) }
       }
   }

--- a/app/src/main/java/com/asfoundation/wallet/manage_wallets/ManageWalletFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/manage_wallets/ManageWalletFragment.kt
@@ -196,7 +196,7 @@ class ManageWalletFragment : BasePageViewFragment() {
     verificationStatus: VerificationStatusCompound
   ) {
     LazyColumn(modifier = Modifier.padding(padding)) {
-      item { ScreenHeader(inactiveWallets.size) }
+      item { ScreenHeader(inactiveWallets.size, walletInfo) }
       item { ActiveWalletCard(walletInfo, verificationStatus) }
 
       items(inactiveWallets) { wallet ->
@@ -268,16 +268,18 @@ class ManageWalletFragment : BasePageViewFragment() {
         fragmentName = fragmentName
       )
       Spacer(modifier = Modifier.height(24.dp))
-      BackupAlertCard(
-        onClickButton = {
-          navigator.navigateToBackup(walletInfo.wallet, walletInfo.name)
-        },
-        hasBackup = walletInfo.hasBackup,
-        backupDate = walletInfo.backupDate,
-        fragmentName = fragmentName,
-        buttonsAnalytics = buttonsAnalytics
-      )
-      Separator()
+      if (walletInfo.email.isNullOrBlank()) {
+        BackupAlertCard(
+          onClickButton = {
+            navigator.navigateToBackup(walletInfo.wallet, walletInfo.name)
+          },
+          hasBackup = walletInfo.hasBackup,
+          backupDate = walletInfo.backupDate,
+          fragmentName = fragmentName,
+          buttonsAnalytics = buttonsAnalytics
+        )
+        Separator()
+      }
       if (
         isVerificationInProcessing(verificationStatus.creditCardStatus, walletInfo.verified) ||
         isVerificationInProcessing(verificationStatus.payPalStatus, walletInfo.verified)
@@ -350,17 +352,19 @@ class ManageWalletFragment : BasePageViewFragment() {
 
       Spacer(modifier = Modifier.height(24.dp))
       Row(verticalAlignment = CenterVertically) {
-        BackupAlertCard(
-          onClickButton = {
-            navigator.navigateToBackup(walletInfo.wallet, walletInfo.name)
-          },
-          hasBackup = walletInfo.hasBackup,
-          backupDate = walletInfo.backupDate,
-          modifier = Modifier.weight(1f),
-          fragmentName = fragmentName,
-          buttonsAnalytics = buttonsAnalytics
-        )
-        Spacer(Modifier.weight(0.05f))
+        if (walletInfo.email.isNullOrBlank()) {
+          BackupAlertCard(
+            onClickButton = {
+              navigator.navigateToBackup(walletInfo.wallet, walletInfo.name)
+            },
+            hasBackup = walletInfo.hasBackup,
+            backupDate = walletInfo.backupDate,
+            modifier = Modifier.weight(1f),
+            fragmentName = fragmentName,
+            buttonsAnalytics = buttonsAnalytics
+          )
+          Spacer(Modifier.weight(0.05f))
+        }
         if (
           isVerificationInProcessing(verificationStatus.creditCardStatus, walletInfo.verified) ||
           isVerificationInProcessing(verificationStatus.payPalStatus, walletInfo.verified)
@@ -514,19 +518,22 @@ class ManageWalletFragment : BasePageViewFragment() {
   }
 
   @Composable
-  fun ScreenHeader(inactiveWalletsQuantity: Int) {
+  fun ScreenHeader(inactiveWalletsQuantity: Int, activeWallet: WalletInfo) {
     Row(
       horizontalArrangement = SpaceBetween,
       verticalAlignment = CenterVertically,
       modifier = Modifier.fillMaxWidth()
     ) {
       ScreenTitle(stringResource(R.string.manage_wallet_view_title))
-      ManagementOptionsBottomSheet(inactiveWalletsQuantity)
+      ManagementOptionsBottomSheet(inactiveWalletsQuantity, activeWallet)
     }
   }
 
   @Composable
-  fun ManagementOptionsBottomSheet(inactiveWalletsQuantity: Int) {
+  fun ManagementOptionsBottomSheet(
+    inactiveWalletsQuantity: Int,
+    activeWallet: WalletInfo
+  ) {
     Row(
       horizontalArrangement = Arrangement.End,
       modifier = Modifier
@@ -537,7 +544,11 @@ class ManageWalletFragment : BasePageViewFragment() {
         imageVector = Icons.Default.MoreVert,
         contentDescription = R.string.action_more_details,
         onClick = {
-          myWalletsNavigator.navigateToManageWalletBottomSheet(inactiveWalletsQuantity == 0)
+          myWalletsNavigator.navigateToManageWalletBottomSheet(
+            inactiveWalletsQuantity == 0,
+            activeWallet.wallet,
+            activeWallet.name
+          )
         },
         paddingIcon = 4.dp,
         background = styleguide_dark_secondary,

--- a/app/src/main/java/com/asfoundation/wallet/manage_wallets/RemoveWalletFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/manage_wallets/RemoveWalletFragment.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.font.FontWeight.Companion.Medium
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
@@ -83,7 +85,14 @@ class RemoveWalletFragment : BasePageViewFragment() {
     viewModel.getWallets(false)
     Scaffold(
       topBar = {
-        Surface { TopBar(isMainBar = false, onClickSupport = { viewModel.displayChat() }, fragmentName = fragmentName, buttonsAnalytics = buttonsAnalytics) }
+        Surface {
+          TopBar(
+            isMainBar = false,
+            onClickSupport = { viewModel.displayChat() },
+            fragmentName = fragmentName,
+            buttonsAnalytics = buttonsAnalytics
+          )
+        }
       },
       containerColor = WalletColors.styleguide_dark,
     ) { padding ->
@@ -119,9 +128,11 @@ class RemoveWalletFragment : BasePageViewFragment() {
 
       item { BalanceCard(walletInfo) }
 
-      item { AlertCard() }
+      if (walletInfo.email.isNullOrBlank()) {
+        item { AlertCard() }
+      }
 
-      item { ActionButtons(walletInfo.wallet, walletInfo.name) }
+      item { ActionButtons(walletInfo.wallet, walletInfo.name, !walletInfo.email.isNullOrBlank()) }
     }
   }
 
@@ -142,7 +153,7 @@ class RemoveWalletFragment : BasePageViewFragment() {
       Card(
         modifier = Modifier.padding(vertical = 24.dp),
         colors =
-        CardDefaults.cardColors(containerColor = WalletColors.styleguide_dark_secondary)
+          CardDefaults.cardColors(containerColor = WalletColors.styleguide_dark_secondary)
       ) {
         Column(
           modifier = Modifier
@@ -250,28 +261,31 @@ class RemoveWalletFragment : BasePageViewFragment() {
   }
 
   @Composable
-  fun ActionButtons(address: String, name: String) {
+  fun ActionButtons(address: String, name: String, hasLogin: Boolean) {
     Column(
       verticalArrangement = Arrangement.spacedBy(16.dp),
       modifier = Modifier
         .padding(top = 48.dp)
         .padding(horizontal = 8.dp)
     ) {
-      ButtonWithText(
-        label = stringResource(id = R.string.backup_button),
-        onClick = { myWalletsNavigator.navigateToBackup(address, name) },
-        labelColor = styleguide_light_grey,
-        backgroundColor = styleguide_primary,
-        buttonType = ButtonType.LARGE,
-        fragmentName = fragmentName,
-        buttonsAnalytics = buttonsAnalytics
-      )
+      if (!hasLogin) {
+        ButtonWithText(
+          label = stringResource(id = R.string.backup_button),
+          onClick = { myWalletsNavigator.navigateToBackup(address, name) },
+          labelColor = styleguide_light_grey,
+          backgroundColor = styleguide_primary,
+          buttonType = ButtonType.LARGE,
+          fragmentName = fragmentName,
+          buttonsAnalytics = buttonsAnalytics
+        )
+      }
 
       ButtonWithText(
         label = stringResource(id = R.string.my_wallets_action_delete_wallet),
         onClick = { viewModel.deleteWallet(address) },
         labelColor = styleguide_light_grey,
-        outlineColor = styleguide_light_grey,
+        outlineColor = if (hasLogin) null else styleguide_light_grey,
+        backgroundColor = if (hasLogin) styleguide_primary else Color.Transparent,
         buttonType = ButtonType.LARGE,
         fragmentName = fragmentName,
         buttonsAnalytics = buttonsAnalytics

--- a/app/src/main/java/com/asfoundation/wallet/manage_wallets/bottom_sheet/ManageWalletBottomSheetFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/manage_wallets/bottom_sheet/ManageWalletBottomSheetFragment.kt
@@ -38,6 +38,11 @@ class ManageWalletBottomSheetFragment : BottomSheetDialogFragment(),
 
     const val HAS_ONE_WALLET = "has_one_wallet"
 
+    const val ACTIVE_WALLET_ADDRESS = "active_wallet_address"
+
+    const val ACTIVE_WALLET_NAME = "active_wallet_name"
+
+
     @JvmStatic
     fun newInstance(): ManageWalletBottomSheetFragment {
       return ManageWalletBottomSheetFragment()
@@ -52,7 +57,10 @@ class ManageWalletBottomSheetFragment : BottomSheetDialogFragment(),
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    setListeners()
+    setListeners(
+      arguments?.getString(ACTIVE_WALLET_ADDRESS),
+      arguments?.getString(ACTIVE_WALLET_NAME)
+    )
     if (arguments?.getBoolean(HAS_ONE_WALLET) == true) {
       views.deleteWalletView.visibility = View.GONE
     }
@@ -69,7 +77,10 @@ class ManageWalletBottomSheetFragment : BottomSheetDialogFragment(),
     return R.style.AppBottomSheetDialogThemeDraggable
   }
 
-  private fun setListeners() {
+  private fun setListeners(
+    walletAddress: String? = null,
+    walletName: String? = null
+  ) {
     views.newWalletView.setOnClickListener {
       dismiss()
       buttonsAnalytics.sendDefaultButtonClickAnalytics(fragmentName, getString(R.string.my_wallets_action_new_wallet))
@@ -85,7 +96,13 @@ class ManageWalletBottomSheetFragment : BottomSheetDialogFragment(),
       buttonsAnalytics.sendDefaultButtonClickAnalytics(fragmentName, getString(R.string.my_wallets_action_recover_wallet))
       navigator.navigateToRecoverWallet()
     }
-
+    views.backupWalletView.setOnClickListener {
+      dismiss()
+      buttonsAnalytics.sendDefaultButtonClickAnalytics(fragmentName, getString(R.string.backup_button))
+      if (walletAddress != null && walletName != null) {
+        navigator.navigateToBackup(walletAddress, walletName)
+      }
+    }
   }
 
   private fun navController(): NavController {

--- a/app/src/main/java/com/asfoundation/wallet/manage_wallets/bottom_sheet/ManageWalletBottomSheetNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/manage_wallets/bottom_sheet/ManageWalletBottomSheetNavigator.kt
@@ -1,11 +1,14 @@
 package com.asfoundation.wallet.manage_wallets.bottom_sheet
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import com.appcoins.wallet.core.arch.data.Navigator
 import com.asf.wallet.R
+import com.asfoundation.wallet.backup.BackupWalletEntryFragment
+import com.asfoundation.wallet.backup.BackupWalletEntryFragment.Companion.WALLET_NAME
 import com.asfoundation.wallet.recover.RecoverActivity
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import javax.inject.Inject
@@ -37,6 +40,16 @@ constructor(
         flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
       }
     openIntent(intent)
+  }
+
+  fun navigateToBackup(
+    walletAddress: String,
+    walletName: String
+  ) {
+    val bundle = Bundle()
+    bundle.putString(BackupWalletEntryFragment.WALLET_ADDRESS_KEY, walletAddress)
+    bundle.putString(WALLET_NAME, walletName)
+    navController.navigate(R.id.action_navigate_to_backup_entry_wallet, args = bundle)
   }
 
   private fun openIntent(intent: Intent) = fragment.requireContext().startActivity(intent)

--- a/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/my_wallets/main/MyWalletsNavigator.kt
@@ -42,9 +42,15 @@ constructor(private val fragment: Fragment, private val navController: NavContro
     bottomSheet.show(fragment.parentFragmentManager, "ManageWallet")
   }
 
-  fun navigateToManageWalletBottomSheet(hasOneWallet: Boolean) {
+  fun navigateToManageWalletBottomSheet(
+    hasOneWallet: Boolean,
+    activeWalletAddress: String,
+    activeWalletName: String
+  ) {
     val bundle = Bundle()
     bundle.putBoolean(ManageWalletBottomSheetFragment.HAS_ONE_WALLET, hasOneWallet)
+    bundle.putString(ManageWalletBottomSheetFragment.ACTIVE_WALLET_ADDRESS, activeWalletAddress)
+    bundle.putString(ManageWalletBottomSheetFragment.ACTIVE_WALLET_NAME, activeWalletName)
     val bottomSheet = ManageWalletBottomSheetFragment.newInstance()
     bottomSheet.arguments = bundle
     bottomSheet.show(fragment.parentFragmentManager, "ManageWallet")

--- a/app/src/main/res/layout/manage_wallet_bottom_sheet_layout.xml
+++ b/app/src/main/res/layout/manage_wallet_bottom_sheet_layout.xml
@@ -98,6 +98,42 @@
   </androidx.constraintlayout.widget.ConstraintLayout>
 
   <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/backup_wallet_view"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_marginTop="32dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/recover_wallet_view"
+      >
+    <ImageView
+        android:id="@+id/backup_wallet_icon"
+        android:layout_width="20dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/ic_backup_wallet"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/styleguide_primary"
+        />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginHorizontal="22dp"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/backup_button"
+        android:textColor="@color/styleguide_light_grey"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@id/backup_wallet_icon"
+        app:layout_constraintStart_toEndOf="@id/backup_wallet_icon"
+        app:layout_constraintTop_toTopOf="@id/backup_wallet_icon"
+        />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/delete_wallet_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -105,7 +141,7 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/recover_wallet_view"
+      app:layout_constraintTop_toBottomOf="@id/backup_wallet_view"
       >
 
     <ImageView

--- a/feature/backup/data/src/main/java/com/appcoins/wallet/feature/backup/data/use_cases/ShouldShowSystemNotificationUseCase.kt
+++ b/feature/backup/data/src/main/java/com/appcoins/wallet/feature/backup/data/use_cases/ShouldShowSystemNotificationUseCase.kt
@@ -21,6 +21,7 @@ class ShouldShowSystemNotificationUseCase @Inject constructor(
     walletInfo.hasBackup.not()
         && meetsLastDismissCondition(walletInfo.wallet)
         && meetsCountConditions(walletInfo.wallet)
+        && walletInfo.email == null
   )
 
   private fun meetsLastDismissCondition(walletAddress: String): Boolean {

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceNewCard.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/BalanceNewCard.kt
@@ -1,5 +1,11 @@
 package com.appcoins.wallet.ui.widgets
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -39,6 +45,8 @@ private const val EMAIL_TEXT_WEIGHT = 400
 private const val EMAIL_TEXT_FONT_SIZE = 14
 
 private const val EMAIL_SPACER_HEIGHT = 12
+
+private const val BACKUP_TWEEN = 300
 
 @Composable
 fun BalanceNewCard(
@@ -136,7 +144,19 @@ fun BalanceNewCard(
         )
       }
       Spacer(modifier = Modifier.height(16.dp))
-      if (showBackup) {
+      AnimatedVisibility(
+        visible = showBackup,
+        enter = fadeIn(animationSpec = tween(BACKUP_TWEEN)) + expandVertically(
+          animationSpec = tween(
+            BACKUP_TWEEN
+          )
+        ),
+        exit = fadeOut(animationSpec = tween(BACKUP_TWEEN)) + shrinkVertically(
+          animationSpec = tween(
+            BACKUP_TWEEN
+          )
+        )
+      ) {
         Row(
           modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
**What does this PR do?**
When the current wallet is linked to a login, the backup is removed from the primary user interface.
Since the wallet has already been saved by the backend, the backup is no longer a concern. This approach aligns with the new login flow.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BalanceNewCard.kt
- [ ] HomeViewModel.kt
- [ ] ManageWalletFragment.kt
- [ ] ManageWalletBalanceBottomSheetFragment.kt
- [ ] manage_wallet_bottom_sheet_layout.xml

**How should this be manually tested?**
Change the current wallet to a Connected wallet and confirm that the banners associated with the wallet’s backup have been removed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5107](https://aptoide.atlassian.net/browse/APPC-5107)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5107]: https://aptoide.atlassian.net/browse/APPC-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ