### PR TITLE
[APPC-5110] Fix | Promo Code Visual Bug

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/home/HomeFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/home/HomeFragment.kt
@@ -477,7 +477,11 @@ class HomeFragment : BasePageViewFragment(), SingleStateFragment<HomeState, Home
             cardItem = promotion,
             fragmentName = fragmentName,
             buttonsAnalytics = buttonsAnalytics,
-            modifier = Modifier.fillParentMaxWidth(if (isLandscape) 0.45f else 0.9f)
+            modifier =
+              if (viewModel.activePromotions.size > 1)
+                Modifier.fillParentMaxWidth(if (isLandscape) 0.45f else 0.9f)
+              else
+                Modifier.fillParentMaxWidth()
           )
         }
       }

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/PromotionsCardComposable.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -329,6 +330,7 @@ fun GetText(
   text?.let {
     TextButton(
       modifier = modifier,
+      contentPadding = PaddingValues( 2.dp),
       onClick = {
         buttonsAnalytics?.sendDefaultButtonClickAnalytics(fragmentName, text)
         action()


### PR DESCRIPTION
**What does this PR do?**
The “Play” and “Get” buttons were being cropped in the Promo Code banner. This PR fix addresses this issue by adding padding to the component, ensuring the correct display.
Additionally, it modifies the carousel behavior on the HomeFragment, causing the active promotion banner to occupy the entire parent width when only one active promotion is present.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PromotionsCardComposable.kt
- [ ] HomeFragment.kt

**How should this be manually tested?**

Activate a promotional campaign and verify that the banner is being displayed correctly within the RewardsFragment.
Additionally, verify the newly implemented carousel behavior within the HomeFragment.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5110](https://aptoide.atlassian.net/browse/APPC-5110)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5110]: https://aptoide.atlassian.net/browse/APPC-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ