### PR TITLE
[APPC-5108] Cloud Gaming Ip fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -265,8 +265,7 @@
         android:name="com.asfoundation.wallet.billing.amazonPay.AmazonPayReturnActivity"
         android:exported="true"
         android:launchMode="singleTask"
-        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow">
-    </activity>
+        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow"></activity>
 
     <activity
         android:name="com.asfoundation.wallet.subscriptions.SubscriptionActivity"
@@ -341,21 +340,20 @@
         android:exported="true"
         android:launchMode="singleTop"
         android:theme="@style/Theme.AppCompat.Transparent.WebPayment"
-        android:windowSoftInputMode="adjustResize">
-    </activity>
+        android:windowSoftInputMode="adjustResize"></activity>
 
     <activity
         android:name="com.asfoundation.wallet.ui.webview_payment.WebWalletResultRouterActivity"
-        android:exported="true"
         android:excludeFromRecents="true"
+        android:exported="true"
         android:theme="@style/Theme.AppCompat.Transparent.NoDisplay">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
+
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data
-            android:scheme="web-wallet-result"
-            />
+
+        <data android:scheme="web-wallet-result" />
       </intent-filter>
     </activity>
 
@@ -363,8 +361,7 @@
         android:name="com.asfoundation.wallet.ui.login.webview_login.WebViewLoginActivity"
         android:exported="true"
         android:theme="@style/Theme.AppCompat.Transparent.WebPayment"
-        android:windowSoftInputMode="adjustResize">
-    </activity>
+        android:windowSoftInputMode="adjustResize"></activity>
 
     <activity
         android:name="com.asfoundation.wallet.ui.login.custom_tab_login.CustomTabLoginActivity"
@@ -384,18 +381,33 @@
     </activity>
 
     <activity
-        android:name="com.asfoundation.wallet.ui.login.custom_tab_login.native_login.NativeLoginActivity"
-        android:theme="@style/Theme.AppCompat.Transparent.CustomTabLogin"
-        android:launchMode="singleTop"
-        android:windowSoftInputMode="adjustResize">
+        android:name="com.asfoundation.wallet.currency_setup_cg.SetUpCurrencyActivity"
+        android:exported="true"
+        android:theme="@style/Theme.AppCompat.Transparent.NoDisplay">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+            android:host="com.appcoins.wallet"
+            android:path="/setup"
+            android:scheme="currency-setup" />
+      </intent-filter>
     </activity>
+
+    <activity
+        android:name="com.asfoundation.wallet.ui.login.custom_tab_login.native_login.NativeLoginActivity"
+        android:launchMode="singleTop"
+        android:theme="@style/Theme.AppCompat.Transparent.CustomTabLogin"
+        android:windowSoftInputMode="adjustResize"></activity>
 
     <activity
         android:name="com.asfoundation.wallet.ui.webview_gamification.WebViewGamificationActivity"
         android:exported="true"
         android:theme="@style/Theme.AppCompat.Transparent.WebviewGamification"
-        android:windowSoftInputMode="adjustResize" >
-    </activity>
+        android:windowSoftInputMode="adjustResize"></activity>
 
     <service
         android:name="com.asfoundation.wallet.transactions.PerkBonusAndGamificationService"

--- a/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/SetUpCurrencyActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/SetUpCurrencyActivity.kt
@@ -1,0 +1,40 @@
+package com.asfoundation.wallet.currency_setup_cg
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.asfoundation.wallet.currency_setup_cg.viewModel.SetUpCurrencyViewModel
+import com.asfoundation.wallet.currency_setup_cg.viewModel.states.SetUpCurrencyVMState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class SetUpCurrencyActivity : ComponentActivity() {
+  private val viewModel: SetUpCurrencyViewModel by viewModels()
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    viewModel.createWalletIfNeeded()
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.state.collect { state ->
+          when (state) {
+            is SetUpCurrencyVMState.Success -> {
+              finish()
+            }
+
+            is SetUpCurrencyVMState.Error -> {
+              finish()
+            }
+
+            else -> {
+              // no-op
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/SetUpCurrencyViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/SetUpCurrencyViewModel.kt
@@ -1,0 +1,61 @@
+package com.asfoundation.wallet.currency_setup_cg.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.appcoins.wallet.core.utils.android_common.RxSchedulers
+import com.appcoins.wallet.core.walletservices.WalletService
+import com.appcoins.wallet.feature.walletInfo.data.wallet.WalletGetterStatus
+import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetWalletInfoUseCase
+import com.asfoundation.wallet.currency_setup_cg.viewModel.states.SetUpCurrencyVMState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class SetUpCurrencyViewModel @Inject constructor(
+  private val walletService: WalletService,
+  private val rxSchedulers: RxSchedulers,
+  private val getWalletInfoUseCase: GetWalletInfoUseCase,
+  initialState: SetUpCurrencyVMState
+) : ViewModel() {
+  private val disposables = CompositeDisposable()
+  private val _state = MutableStateFlow(initialState)
+  val state = _state.asStateFlow()
+
+  fun createWalletIfNeeded() {
+    disposables
+      .add(
+        walletService.findWalletOrCreate()
+          .subscribeOn(rxSchedulers.io)
+          .observeOn(rxSchedulers.io)
+          .doOnSubscribe {
+            viewModelScope
+              .launch {
+                _state.emit(SetUpCurrencyVMState.Processing)
+              }
+          }
+          .flatMap { walletAddress ->
+            Observable.just(walletAddress)
+              .filter { it != WalletGetterStatus.CREATING.toString() }
+              .flatMapSingle {
+                getWalletInfoUseCase(it, false)
+              }
+          }
+          .subscribe({
+            viewModelScope
+              .launch {
+                _state.emit(SetUpCurrencyVMState.Success)
+              }
+          }, {
+            viewModelScope
+              .launch {
+                _state.emit(SetUpCurrencyVMState.Error)
+              }
+          })
+      )
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/dependency_injection/SetUpCurrencyModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/dependency_injection/SetUpCurrencyModule.kt
@@ -1,0 +1,16 @@
+package com.asfoundation.wallet.currency_setup_cg.viewModel.dependency_injection
+
+import com.asfoundation.wallet.currency_setup_cg.viewModel.states.SetUpCurrencyVMState
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal object SetUpCurrencyModule {
+  @Provides
+  fun providesSetUpCurrencyVMStates(): SetUpCurrencyVMState {
+    return SetUpCurrencyVMState.Idle
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/states/SetUpCurrencyVMState.kt
+++ b/app/src/main/java/com/asfoundation/wallet/currency_setup_cg/viewModel/states/SetUpCurrencyVMState.kt
@@ -1,0 +1,8 @@
+package com.asfoundation.wallet.currency_setup_cg.viewModel.states
+
+internal sealed interface SetUpCurrencyVMState {
+  object Idle : SetUpCurrencyVMState
+  object Processing : SetUpCurrencyVMState
+  object Success : SetUpCurrencyVMState
+  object Error : SetUpCurrencyVMState
+}

--- a/app/src/main/java/com/asfoundation/wallet/ui/login/custom_tab_login/viewModel/CustomTabLoginViewModel.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/login/custom_tab_login/viewModel/CustomTabLoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.asfoundation.wallet.ui.login.custom_tab_login.viewModel
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.core.utils.android_common.RxSchedulers
@@ -34,7 +35,7 @@ internal class CustomTabLoginViewModel @Inject constructor(
   private val fetchUserKeyUseCase: FetchUserKeyUseCase,
   private val logger: Logger,
   initialStates: CustomTabVMStates = Initial,
-) : androidx.lifecycle.ViewModel() {
+) : ViewModel() {
   companion object {
     private const val TAG = "CustomTabLoginVM"
   }


### PR DESCRIPTION
**What does this PR do?**

Develops a new Activity responsible for creating a wallet and verifying the user’s local currency prior to the first purchase. This will enable the cloud gaming platform to display the accurate in-game currency before the user initiates a payment.

A deeplink is invoked to initiate this operation before the game is launched.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SetUpCurrencyActivity.kt

**How should this be manually tested?**

Without completing the onboard flow, initiate the deeplink command `adb shell am start -a android.intent.action.VIEW -d “currency-setup://com.appcoins.wallet/setup”`. Subsequently, navigate to the game within the cloud gaming interface. Upon the game’s availability, the currency displayed should reflect the user’s local currency rather than the server’s currency. Additionally, upon initiating a purchase, a new wallet should not be created.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-5108](https://aptoide.atlassian.net/browse/APPC-5108)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[APPC-5108]: https://aptoide.atlassian.net/browse/APPC-5108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ