### PR TITLE
[DOT-131] NavBar Padding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
 
   defaultConfig {
     applicationId = "com.appcoins.wallet"
-    versionCode = 386
-    versionName = "4.19.4"
+    versionCode = 387
+    versionName = "4.19.5"
 
     externalNativeBuild {
       cmake {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -132,7 +132,6 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
         when {
           isFinishingPurchase -> close()
           views.fullscreenComposeView.isVisible -> {
-//            views.fullscreenComposeView.visibility = View.GONE
             isEnabled = false
             onBackPressedDispatcher.onBackPressed()
             isEnabled = true

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -7,6 +7,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.ui.platform.ComposeView
 import by.kirich1409.viewbindingdelegate.viewBinding
@@ -14,7 +16,6 @@ import com.appcoins.wallet.billing.AppcoinsBillingBinder
 import com.appcoins.wallet.core.analytics.analytics.common.ButtonsAnalytics
 import com.appcoins.wallet.core.utils.jvm_common.Logger
 import com.appcoins.wallet.ui.widgets.top_bar.TopBar
-import com.asf.wallet.BuildConfig
 import com.asf.wallet.R
 import com.asf.wallet.databinding.TopUpActivityLayoutBinding
 import com.asfoundation.wallet.backup.BackupNotificationUtils
@@ -45,6 +46,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import java.util.Objects
 import javax.inject.Inject
+import androidx.core.view.isVisible
 
 
 @AndroidEntryPoint
@@ -81,6 +83,12 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
   private var firstImpression = true
 
   private val views by viewBinding(TopUpActivityLayoutBinding::bind)
+
+  private val webViewLauncher = registerForActivityResult(
+    ActivityResultContracts.StartActivityForResult()
+  ) { result ->
+    presenter.processActivityResult(WEB_VIEW_REQUEST_CODE, result.resultCode, result.data)
+  }
 
   companion object {
     @JvmStatic
@@ -119,6 +127,25 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
         TopBar(isMainBar = false, onClickSupport = { presenter.displayChat() }, fragmentName = fragmentName, buttonsAnalytics = buttonsAnalytics)
       }
     }
+    onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
+        when {
+          isFinishingPurchase -> close()
+          views.fullscreenComposeView.isVisible -> {
+//            views.fullscreenComposeView.visibility = View.GONE
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+            isEnabled = true
+          }
+          supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
+          else -> {
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+            isEnabled = true
+          }
+        }
+      }
+    })
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -223,24 +250,12 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
     finish()
   }
 
-  override fun onBackPressed() {
-    when {
-      isFinishingPurchase -> close()
-      views.fullscreenComposeView.visibility == View.VISIBLE -> {
-//        views.fullscreenComposeView.visibility = View.GONE
-        super.onBackPressed()
-      }
-      supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
-      else -> super.onBackPressed()
-    }
-  }
-
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     if (item.itemId == android.R.id.home) {
       when {
         isFinishingPurchase -> close()
         supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
-        else -> super.onBackPressed()
+        else -> onBackPressedDispatcher.onBackPressed()
       }
       return true
     }
@@ -316,7 +331,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
   }
 
   override fun navigateToUri(url: String) {
-    startActivityForResult(WebViewActivity.newIntent(this, url), WEB_VIEW_REQUEST_CODE)
+    webViewLauncher.launch(WebViewActivity.newIntent(this, url))
   }
 
   override fun uriResults() = results
@@ -331,15 +346,15 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, UriNavigator {
 
   override fun getTryAgainClicks() = RxView.clicks(views.layoutError.tryAgain)
 
-  override fun setFinishingPurchase(newState: Boolean) {
-    isFinishingPurchase = newState
+  override fun setFinishingPurchase(value: Boolean) {
+    isFinishingPurchase = value
   }
 
   override fun cancelPayment() {
     if (supportFragmentManager.backStackEntryCount != 0) {
       supportFragmentManager.popBackStackImmediate()
     } else {
-      super.onBackPressed()
+      onBackPressedDispatcher.onBackPressed()
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/verification/ui/paypal/VerificationPaypalFragment.kt
@@ -58,7 +58,6 @@ import com.appcoins.wallet.ui.widgets.component.WalletCodeTextField
 import com.appcoins.wallet.ui.widgets.expanded
 import com.asf.wallet.R
 import com.asfoundation.wallet.ui.WebViewResults
-import com.asfoundation.wallet.ui.iab.WebViewActivity
 import com.asfoundation.wallet.verification.ui.credit_card.VerificationAnalytics
 import com.asfoundation.wallet.verification.ui.credit_card.intro.VerificationInfoModel
 import com.asfoundation.wallet.verification.ui.paypal.VerificationPaypalViewModel.VerificationPaypalState

--- a/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/top_bar/TopBarComposable.kt
+++ b/ui/widgets/src/main/java/com/appcoins/wallet/ui/widgets/top_bar/TopBarComposable.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -47,6 +48,7 @@ fun TopBar(
     modifier = Modifier
       .fillMaxWidth()
       .background(WalletColors.styleguide_dark)
+      .statusBarsPadding()
       .height(64.dp)
       .padding(start = 16.dp, end = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
@@ -85,6 +87,7 @@ fun TopBar(
     Modifier
       .fillMaxWidth()
       .background(WalletColors.styleguide_dark)
+      .statusBarsPadding()
       .padding(start = 16.dp, end = 4.dp)
       .height(64.dp),
     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
**What does this PR address?**

This PR resolves the padding issue in the `NavBar` Composable, ensuring its correct display across all screens that utilize it.

Additionally, it addresses the warning in `TopUpActivity` regarding the deprecated `onBackPressed` and `startActivityForResult` calls.
**Database modifications?**
No
**Where should the reviewer begin?**

- [ ] TopBarComposable.kt
- [ ] TopUpActivity.kt

**How should this be manually tested?**

```mermaid
flowchart TD               
      Home(["Home Screen"])
                                                                                                                                                                            
      Home -->|"Top Up"| TopUp(["Top Up"])
      Home -->|"Settings"| Settings(["Settings"])                                                                                                                        
      Home -->|"More"| BottomSheet(["Bottom Sheet"])                                                                                                                   

      Settings -->|"Currency"| ChangeCurrency(["Change Currency"])

      BottomSheet -->|"Manage Wallets"| ManageWallets(["Manage Wallets"])
      BottomSheet -->|"Back Up"| BackUpWallet(["Back Up Wallet"])

      classDef screen  fill:#1E1E2E,stroke:#89B4FA,stroke-width:2px,color:#CDD6F4,rx:12
      classDef sheet   fill:#181825,stroke:#A6E3A1,stroke-width:2px,color:#CDD6F4,rx:12

      class Home,TopUp,Settings,ChangeCurrency,ManageWallets,BackUpWallet screen
      class BottomSheet sheet
```
Navigate to any screen that incorporates the TopBar as a component (e.g., TopUp screen) and verify that the TopBar is displayed accurately.

**What are the relevant tickets?**

Tickets related to this pull-request: [DOT-131](https://aptoide.atlassian.net/browse/DOT-131)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database modifications?
- [ ] Database migration (if applicable)?
- [ ] Remove comments, unused code, and forgotten testing logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[DOT-131]: https://aptoide.atlassian.net/browse/DOT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ