### PR TITLE
[DOT-139] Cloud Gaming | x-client-country

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
 
   defaultConfig {
     applicationId = "com.appcoins.wallet"
-    versionCode = 386
-    versionName = "4.19.4"
+    versionCode = 387
+    versionName = "4.19.5"
 
     externalNativeBuild {
       cmake {

--- a/app/src/main/java/com/asfoundation/wallet/repository/IpCountryCodeProvider.java
+++ b/app/src/main/java/com/asfoundation/wallet/repository/IpCountryCodeProvider.java
@@ -2,7 +2,6 @@ package com.asfoundation.wallet.repository;
 
 import androidx.annotation.NonNull;
 import com.appcoins.wallet.core.network.backend.api.CountryApi;
-import com.appcoins.wallet.core.network.backend.model.CountryResponse;
 import com.appcoins.wallet.core.utils.jvm_common.CountryCodeProvider;
 import io.reactivex.Single;
 import it.czerwinski.android.hilt.annotations.BoundTo;
@@ -17,7 +16,7 @@ import javax.inject.Inject;
   }
 
   @NonNull @Override public Single<String> getCountryCode() {
-    return countryApi.getCountryCode()
-        .map(CountryResponse::getCountryCode);
+    return countryApi.getCountryCode(null)
+        .map(countryResponse -> countryResponse.getCountryCode() != null ? countryResponse.getCountryCode() : "");
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentOspUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentOspUseCase.kt
@@ -81,11 +81,11 @@ class CreateWebViewPaymentOspUseCase @Inject constructor(
             "&version=${appVersion ?: ""}" +
             "&currency=".plus(if (getCachedCurrencyUseCase().equals("null")) "" else getCachedCurrencyUseCase()) +
             "&user_props=${analytics.getIndicativeSuperProperties().convertToBase64Url()}" +
-            if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
-            if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "" +
-            if (generateWebLoginUrlUseCase.isCloudGaming()) {
+            (if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "") +
+            (if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "") +
+            (if (generateWebLoginUrlUseCase.isCloudGaming()) {
               "&user=${encrypt}"
-            } else ""
+            } else "")
       }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentOspUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentOspUseCase.kt
@@ -13,7 +13,7 @@ import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCountryCod
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.ui.iab.InAppPurchaseInteractor
 import com.asfoundation.wallet.ui.login.usecases.GenerateWebLoginUrlUseCase
-import com.asfoundation.wallet.util.tuples.Septuple
+import com.asfoundation.wallet.util.tuples.Octuple
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -29,6 +29,7 @@ class CreateWebViewPaymentOspUseCase @Inject constructor(
   val generateWebLoginUrlUseCase: GenerateWebLoginUrlUseCase,
   val getEncryptedPrivateKeyUseCase: GetEncryptedPrivateKeyUseCase,
   val getCloudIpUseCase: GetCloudIpUseCase,
+  val getCloudCountryCodeUseCase: GetCloudCountryCodeUseCase,
   val rxSchedulers: RxSchedulers,
 ) {
 
@@ -43,12 +44,13 @@ class CreateWebViewPaymentOspUseCase @Inject constructor(
       walletService.getAndSignCurrentWalletAddress().subscribeOn(rxSchedulers.io),
       ewtObtainer.getEwtAuthenticationNoBearer().subscribeOn(rxSchedulers.io),
       getCountryCodeUseCase().subscribeOn(rxSchedulers.io),
-      addressService.getAttribution(transaction?.domain ?: "").subscribeOn(rxSchedulers.io),
+      addressService.getAttribution(transaction.domain ?: "").subscribeOn(rxSchedulers.io),
       getCurrentPromoCodeUseCase().subscribeOn(rxSchedulers.io),
       getEncryptedPrivateKeyUseCase().subscribeOn(rxSchedulers.io),
       Single.just (getCloudIpUseCase() ?: "").subscribeOn(rxSchedulers.io),
-    ) { walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud ->
-      Septuple(walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud)
+      Single.just (getCloudCountryCodeUseCase() ?: "").subscribeOn(rxSchedulers.io),
+    ) { walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud, cloudCountry ->
+      Octuple(walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud, cloudCountry)
     }
       .map { args ->
         val walletModel = args.first
@@ -58,6 +60,7 @@ class CreateWebViewPaymentOspUseCase @Inject constructor(
         val promoCode = args.fifth
         val encrypt = args.sixth
         val ipCloud = args.seventh
+        val cloudCountry = args.eighth
 
         "$baseWebViewPaymentUrl?" +
             "referrer_url=${
@@ -78,7 +81,8 @@ class CreateWebViewPaymentOspUseCase @Inject constructor(
             "&version=${appVersion ?: ""}" +
             "&currency=".plus(if (getCachedCurrencyUseCase().equals("null")) "" else getCachedCurrencyUseCase()) +
             "&user_props=${analytics.getIndicativeSuperProperties().convertToBase64Url()}" +
-            if (!ipCloud.isNullOrBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
+            if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
+            if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "" +
             if (generateWebLoginUrlUseCase.isCloudGaming()) {
               "&user=${encrypt}"
             } else ""

--- a/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentSdkUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentSdkUseCase.kt
@@ -87,11 +87,11 @@ class CreateWebViewPaymentSdkUseCase @Inject constructor(
             "&version=${appVersion ?: ""}" +
             "&currency=".plus(if (getCachedCurrencyUseCase().equals("null")) "" else getCachedCurrencyUseCase()) +
             "&user_props=${analytics.getIndicativeSuperProperties().convertToBase64Url()}" +
-            if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
-            if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "" +
-            if (generateWebLoginUrlUseCase.isCloudGaming()) {
+            (if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "") +
+            (if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "") +
+            (if (generateWebLoginUrlUseCase.isCloudGaming()) {
               "&user=${encrypt}"
-            } else ""
+            } else "")
       }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentSdkUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/CreateWebViewPaymentSdkUseCase.kt
@@ -13,7 +13,7 @@ import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCountryCod
 import com.asfoundation.wallet.entity.TransactionBuilder
 import com.asfoundation.wallet.ui.iab.InAppPurchaseInteractor
 import com.asfoundation.wallet.ui.login.usecases.GenerateWebLoginUrlUseCase
-import com.asfoundation.wallet.util.tuples.Septuple
+import com.asfoundation.wallet.util.tuples.Octuple
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -29,6 +29,7 @@ class CreateWebViewPaymentSdkUseCase @Inject constructor(
   val generateWebLoginUrlUseCase: GenerateWebLoginUrlUseCase,
   val getEncryptedPrivateKeyUseCase: GetEncryptedPrivateKeyUseCase,
   val getCloudIpUseCase: GetCloudIpUseCase,
+  val getCloudCountryCodeUseCase: GetCloudCountryCodeUseCase,
   val rxSchedulers: RxSchedulers,
 ) {
 
@@ -48,8 +49,9 @@ class CreateWebViewPaymentSdkUseCase @Inject constructor(
       getCurrentPromoCodeUseCase().subscribeOn(rxSchedulers.io),
       getEncryptedPrivateKeyUseCase().subscribeOn(rxSchedulers.io),
       Single.just(getCloudIpUseCase() ?: "").subscribeOn(rxSchedulers.io),
-    ) { walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud ->
-      Septuple(walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud)
+      Single.just(getCloudCountryCodeUseCase() ?: "").subscribeOn(rxSchedulers.io),
+    ) { walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud, cloudCountry ->
+      Octuple(walletModel, ewt, country, oemId, promoCode, encrypt, ipCloud, cloudCountry)
     }
       .map { args ->
         val walletModel = args.first
@@ -59,6 +61,7 @@ class CreateWebViewPaymentSdkUseCase @Inject constructor(
         val promoCode = args.fifth
         val encrypt = args.sixth
         val ipCloud = args.seventh
+        val cloudCountry = args.eighth
 
         "$baseWebViewPaymentUrl?" +
             "&country=$country" +
@@ -84,7 +87,8 @@ class CreateWebViewPaymentSdkUseCase @Inject constructor(
             "&version=${appVersion ?: ""}" +
             "&currency=".plus(if (getCachedCurrencyUseCase().equals("null")) "" else getCachedCurrencyUseCase()) +
             "&user_props=${analytics.getIndicativeSuperProperties().convertToBase64Url()}" +
-            if (!ipCloud.isNullOrBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
+            if (ipCloud.isNotBlank()) "&ip_cloud_gaming=$ipCloud" else "" +
+            if (cloudCountry.isNotBlank()) "&country_cloud_gaming=$cloudCountry" else "" +
             if (generateWebLoginUrlUseCase.isCloudGaming()) {
               "&user=${encrypt}"
             } else ""

--- a/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/GetCloudCountryCodeUseCase.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/webview_payment/usecases/GetCloudCountryCodeUseCase.kt
@@ -1,0 +1,12 @@
+package com.asfoundation.wallet.ui.webview_payment.usecases
+
+import com.appcoins.wallet.sharedpreferences.CommonsPreferencesDataSource
+import javax.inject.Inject
+
+class GetCloudCountryCodeUseCase @Inject constructor(
+  private val commonsPreferencesDataSource: CommonsPreferencesDataSource
+) {
+  operator fun invoke(): String? {
+    return commonsPreferencesDataSource.getCountryCode()
+  }
+}

--- a/app/src/main/java/com/asfoundation/wallet/util/tuples/Octuple.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/tuples/Octuple.kt
@@ -1,0 +1,3 @@
+package com.asfoundation.wallet.util.tuples
+
+data class Octuple<A, B, C, D, E, F, G, H>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E, val sixth: F, val seventh: G, val eighth: H)

--- a/app/src/main/java/com/asfoundation/wallet/util/tuples/Septuple.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/tuples/Septuple.kt
@@ -1,3 +1,0 @@
-package com.asfoundation.wallet.util.tuples
-
-data class Septuple<A, B, C, D, E, F, G>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E, val sixth: F, val seventh: G)

--- a/app/src/test/java/com/asfoundation/wallet/service/AccountWalletServiceTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/service/AccountWalletServiceTest.kt
@@ -8,6 +8,7 @@ import com.appcoins.wallet.feature.walletInfo.data.wallet.AccountWalletService
 import com.appcoins.wallet.feature.walletInfo.data.wallet.domain.Wallet
 import com.appcoins.wallet.feature.walletInfo.data.wallet.repository.WalletRepositoryType
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.CreateWalletUseCase
+import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCountryCodeUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCurrentWalletUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetPrivateKeyUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.RecoverEntryPrivateKeyUseCase
@@ -61,6 +62,9 @@ class AccountWalletServiceTest {
 
   @Mock
   lateinit var walletRepositoryType: WalletRepositoryType
+  @Mock
+  lateinit var getCountryCodeUseCase: GetCountryCodeUseCase
+
 
   @Mock
   lateinit var syncScheduler: ExecutorScheduler
@@ -96,7 +100,8 @@ class AccountWalletServiceTest {
       getCurrentWalletUseCase = getCurrentWalletUseCase,
       context = context,
       recoverEntryPrivateKeyUseCase = recoverEntryPrivateKeyUseCase,
-      commonsPreferencesDataSource = commonsPreferencesDataSource
+      commonsPreferencesDataSource = commonsPreferencesDataSource,
+      getCountryCodeUseCase = getCountryCodeUseCase
     )
   }
 

--- a/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/api/CountryApi.kt
+++ b/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/api/CountryApi.kt
@@ -3,11 +3,12 @@ package com.appcoins.wallet.core.network.backend.api
 import com.appcoins.wallet.core.network.backend.model.CountryResponse
 import io.reactivex.Single
 import retrofit2.http.GET
+import retrofit2.http.Header
 
 interface CountryApi {
   @GET("appc/countrycode")
   fun getCountryCode(): Single<CountryResponse?>?
 
   @GET("appc/countrycode")
-  fun getCountryCodeForRefund(): Single<CountryResponse>
+  fun getCountryCode(@Header("x-client-ip") clientIp: String?): Single<CountryResponse>
 }

--- a/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/api/CountryApi.kt
+++ b/core/network/backend/src/main/java/com/appcoins/wallet/core/network/backend/api/CountryApi.kt
@@ -7,8 +7,5 @@ import retrofit2.http.Header
 
 interface CountryApi {
   @GET("appc/countrycode")
-  fun getCountryCode(): Single<CountryResponse?>?
-
-  @GET("appc/countrycode")
   fun getCountryCode(@Header("x-client-ip") clientIp: String?): Single<CountryResponse>
 }

--- a/core/network/base/src/main/java/com/appcoins/wallet/core/network/base/interceptors/CloudIpInterceptor.kt
+++ b/core/network/base/src/main/java/com/appcoins/wallet/core/network/base/interceptors/CloudIpInterceptor.kt
@@ -11,11 +11,17 @@ class CloudIpInterceptor @Inject constructor(
 
   override fun intercept(chain: Interceptor.Chain): Response {
     val cloudIp = commonsPreferencesDataSource.getCloudIp()
+    val countryCode = commonsPreferencesDataSource.getCountryCode()
     return if (!cloudIp.isNullOrBlank())
       chain.proceed(
       chain.request()
         .newBuilder()
         .header("x-client-ip", cloudIp)
+        .let {
+          if (!countryCode.isNullOrBlank())
+            it.header("x-client-country", countryCode)
+          else it
+        }
         .build()
     )
     else

--- a/core/shared-preferences/src/main/java/com/appcoins/wallet/sharedpreferences/CommonsPreferencesDataSource.kt
+++ b/core/shared-preferences/src/main/java/com/appcoins/wallet/sharedpreferences/CommonsPreferencesDataSource.kt
@@ -23,6 +23,7 @@ constructor(private val sharedPreferences: SharedPreferences) {
     private const val HAS_BEEN_IN_SETTINGS = "has_been_in_settings"
     private const val NUMBER_OF_TIMES_IN_HOME = "number_of_times_in_home"
     private const val CLOUD_IP = "cloud_ip"
+    private const val COUNTRY_CODE = "country_code"
   }
 
   fun hasCompletedOnboarding() = sharedPreferences.getBoolean(ONBOARDING_COMPLETE_KEY, false)
@@ -80,4 +81,7 @@ constructor(private val sharedPreferences: SharedPreferences) {
   fun setCloudIp(ip: String?) = sharedPreferences.edit { putString(CLOUD_IP, ip) }
 
   fun getCloudIp(): String? = sharedPreferences.getString(CLOUD_IP, null)
+  fun setCountryCode(countryCode: String?) = sharedPreferences.edit { putString(COUNTRY_CODE, countryCode) }
+
+  fun getCountryCode(): String? = sharedPreferences.getString(COUNTRY_CODE, null)
 }

--- a/core/utils/jvm-common/src/main/java/com/appcoins/wallet/core/utils/jvm_common/CountryCodeProvider.kt
+++ b/core/utils/jvm-common/src/main/java/com/appcoins/wallet/core/utils/jvm_common/CountryCodeProvider.kt
@@ -10,7 +10,7 @@ fun convertCountryCode(countryCode: String): ByteArray {
   val data = ByteArray(2)
   val chars = countryCode.toCharArray()
   //mapDarkIcons country code for contract's format
-  val index = (chars[0].toInt() - 65) * 26 + (chars[1].toInt() - 65)
+  val index = (chars[0].code - 65) * 26 + (chars[1].code - 65)
   data[0] = (index ushr 8 and 0xFF).toByte()
   data[1] = (index and 0xFF).toByte()
   return data

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/country_code/CountryCodeRepository.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/country_code/CountryCodeRepository.kt
@@ -10,13 +10,7 @@ class CountryCodeRepository @Inject constructor(
   private val refundDisclaimerPreferencesDataSource: RefundDisclaimerPreferencesDataSource,
   private val countryApi: CountryApi
 ) {
-
-
-  fun getCountryCode(): Single<CountryResponse> {
-    return countryApi.getCountryCode(clientIp = null)
-  }
-
-  fun getCountryCode(ip: String): Single<CountryResponse> {
+  fun getCountryCode(ip: String?): Single<CountryResponse> {
     return countryApi.getCountryCode(clientIp = ip)
   }
 

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/country_code/CountryCodeRepository.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/country_code/CountryCodeRepository.kt
@@ -13,7 +13,11 @@ class CountryCodeRepository @Inject constructor(
 
 
   fun getCountryCode(): Single<CountryResponse> {
-    return countryApi.getCountryCodeForRefund()
+    return countryApi.getCountryCode(clientIp = null)
+  }
+
+  fun getCountryCode(ip: String): Single<CountryResponse> {
+    return countryApi.getCountryCode(clientIp = ip)
   }
 
   fun getCachedShowRefundDisclaimer(): Boolean {

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
@@ -10,6 +10,7 @@ import com.appcoins.wallet.feature.walletInfo.data.wallet.domain.Wallet
 import com.appcoins.wallet.feature.walletInfo.data.wallet.domain.WalletKeyStore
 import com.appcoins.wallet.feature.walletInfo.data.wallet.repository.WalletRepositoryType
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.CreateWalletUseCase
+import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCountryCodeUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetCurrentWalletUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.GetPrivateKeyUseCase
 import com.appcoins.wallet.feature.walletInfo.data.wallet.usecases.RecoverEntryPrivateKeyUseCase
@@ -18,6 +19,7 @@ import com.appcoins.wallet.sharedpreferences.CommonsPreferencesDataSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.internal.schedulers.ExecutorScheduler
 import it.czerwinski.android.hilt.annotations.BoundTo
 import org.web3j.crypto.ECKeyPair
@@ -38,8 +40,11 @@ class AccountWalletService @Inject constructor(
   private val getCurrentWalletUseCase: GetCurrentWalletUseCase,
   private val recoverEntryPrivateKeyUseCase: RecoverEntryPrivateKeyUseCase,
   private val commonsPreferencesDataSource: CommonsPreferencesDataSource,
+  private val getCountryCodeUseCase: GetCountryCodeUseCase,
   @ApplicationContext private val context: Context,
 ) : WalletService {
+
+  private val disposables = CompositeDisposable()
 
   private val PRIVATE_RADIX = 16
   private val N_VALUE = 1 shl 9
@@ -61,7 +66,16 @@ class AccountWalletService @Inject constructor(
     }
     .onErrorResumeNext { _: Throwable ->
       val ip = readIpFromFile()
-      if(!ip.isNullOrBlank()) commonsPreferencesDataSource.setCloudIp(ip)
+      if (!ip.isNullOrBlank()) {
+        commonsPreferencesDataSource.setCloudIp(ip)
+        disposables.add(
+          getCountryCodeUseCase(ip)
+            .subscribe(
+              { commonsPreferencesDataSource.setCountryCode(it) },
+              { /* best effort — ignore errors */ }
+            )
+        )
+      }
 
       val file = File(context.filesDir, "wallet")
       val key: String? = if (file.exists())

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
@@ -78,7 +78,7 @@ class AccountWalletService @Inject constructor(
       persistCountryCode.flatMapObservable {
         val file = File(context.filesDir, "wallet")
         val key: String? = if (file.exists())
-          try { file.readText(Charsets.UTF_8) } catch (e: Exception) { null }
+          try { file.readText(Charsets.UTF_8) } catch (_: Exception) { null }
         else null
         if (!key.isNullOrBlank()) {
           Observable.just(WalletGetterStatus.CREATING.toString())
@@ -109,7 +109,7 @@ class AccountWalletService @Inject constructor(
   private fun readIpFromFile(): String? {
     val file = File(context.filesDir, "ip")
     return if (file.exists())
-      try { file.readText(Charsets.UTF_8) } catch (e: Exception) { null }
+      try { file.readText(Charsets.UTF_8) } catch (_: Exception) { null }
     else null
   }
 

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/AccountWalletService.kt
@@ -19,7 +19,6 @@ import com.appcoins.wallet.sharedpreferences.CommonsPreferencesDataSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Observable
 import io.reactivex.Single
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.internal.schedulers.ExecutorScheduler
 import it.czerwinski.android.hilt.annotations.BoundTo
 import org.web3j.crypto.ECKeyPair
@@ -44,8 +43,6 @@ class AccountWalletService @Inject constructor(
   @ApplicationContext private val context: Context,
 ) : WalletService {
 
-  private val disposables = CompositeDisposable()
-
   private val PRIVATE_RADIX = 16
   private val N_VALUE = 1 shl 9
   private val P_VALUE = 1
@@ -66,45 +63,46 @@ class AccountWalletService @Inject constructor(
     }
     .onErrorResumeNext { _: Throwable ->
       val ip = readIpFromFile()
-      if (!ip.isNullOrBlank()) {
-        commonsPreferencesDataSource.setCloudIp(ip)
-        disposables.add(
-          getCountryCodeUseCase(ip)
-            .subscribe(
-              { commonsPreferencesDataSource.setCountryCode(it) },
-              { /* best effort — ignore errors */ }
-            )
-        )
-      }
 
-      val file = File(context.filesDir, "wallet")
-      val key: String? = if (file.exists())
-        try { file.readText(Charsets.UTF_8) } catch (e: Exception) { null }
-      else null
-      if (!key.isNullOrBlank()) {
-        Observable.just(WalletGetterStatus.CREATING.toString())
-          .mergeWith(
-            recoverEntryPrivateKeyUseCase(keyStore = WalletKeyStore(null, key))
-              .map {
-                when (it) {
-                  is SuccessfulEntryRecover -> {
-                    it.address
+      val persistCountryCode: Single<Unit> =
+        if (!ip.isNullOrBlank()) {
+          commonsPreferencesDataSource.setCloudIp(ip)
+          getCountryCodeUseCase(ip)
+            .doOnSuccess { commonsPreferencesDataSource.setCountryCode(it) }
+            .onErrorReturnItem("") // best effort — ignore errors
+            .map { }
+        } else {
+          Single.just(Unit)
+        }
+
+      persistCountryCode.flatMapObservable {
+        val file = File(context.filesDir, "wallet")
+        val key: String? = if (file.exists())
+          try { file.readText(Charsets.UTF_8) } catch (e: Exception) { null }
+        else null
+        if (!key.isNullOrBlank()) {
+          Observable.just(WalletGetterStatus.CREATING.toString())
+            .mergeWith(
+              recoverEntryPrivateKeyUseCase(keyStore = WalletKeyStore(null, key))
+                .map {
+                  when (it) {
+                    is SuccessfulEntryRecover -> it.address
+                    else -> ""
                   }
-                  else -> ""
                 }
-              }
-          )
-          .flatMap {
-            registerFirebaseTokenUseCase.registerFirebaseToken(wallet = Wallet(it))
-              .map { wallet -> wallet.address }.toObservable()
-          }
-      } else {
-        Observable.just(WalletGetterStatus.CREATING.toString())
-          .mergeWith(createWalletUseCase("Main Wallet").map { it.address }.toObservable())
-          .flatMap {
-            registerFirebaseTokenUseCase.registerFirebaseToken(wallet = Wallet(it))
-              .map { wallet -> wallet.address }.toObservable()
-          }
+            )
+            .flatMap {
+              registerFirebaseTokenUseCase.registerFirebaseToken(wallet = Wallet(it))
+                .map { wallet -> wallet.address }.toObservable()
+            }
+        } else {
+          Observable.just(WalletGetterStatus.CREATING.toString())
+            .mergeWith(createWalletUseCase("Main Wallet").map { it.address }.toObservable())
+            .flatMap {
+              registerFirebaseTokenUseCase.registerFirebaseToken(wallet = Wallet(it))
+                .map { wallet -> wallet.address }.toObservable()
+            }
+        }
       }
     }
 

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetCountryCodeUseCase.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetCountryCodeUseCase.kt
@@ -15,4 +15,11 @@ class GetCountryCodeUseCase @Inject constructor(
       }
   }
 
+  operator fun invoke(ip: String): Single<String> {
+    return countryCodeRepository.getCountryCode(ip)
+      .map { countryResponse ->
+        countryResponse.countryCode ?: ""
+      }
+  }
+
 }

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetCountryCodeUseCase.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetCountryCodeUseCase.kt
@@ -7,15 +7,7 @@ import javax.inject.Inject
 class GetCountryCodeUseCase @Inject constructor(
   private val countryCodeRepository: CountryCodeRepository
 ) {
-
-  operator fun invoke(): Single<String> {
-    return countryCodeRepository.getCountryCode()
-      .map { countryResponse ->
-        countryResponse.countryCode ?: ""
-      }
-  }
-
-  operator fun invoke(ip: String): Single<String> {
+  operator fun invoke(ip: String? = null): Single<String> {
     return countryCodeRepository.getCountryCode(ip)
       .map { countryResponse ->
         countryResponse.countryCode ?: ""

--- a/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetShowRefundDisclaimerCodeUseCase.kt
+++ b/feature/wallet-info/data/src/main/java/com/appcoins/wallet/feature/walletInfo/data/wallet/usecases/GetShowRefundDisclaimerCodeUseCase.kt
@@ -11,7 +11,7 @@ class GetShowRefundDisclaimerCodeUseCase @Inject constructor(
 ) {
 
   operator fun invoke(): Single<CountryResponse> {
-    return countryCodeRepository.getCountryCode()
+    return countryCodeRepository.getCountryCode(null)
   }
 
 }


### PR DESCRIPTION
**What is the purpose of this PR?**
In the Cloud Gaming context, this PR adds the `x-client-country` information to the `x-client-ip`.

**Has the database been modified?**

No

**Where should the reviewer begin?**

- [ ] AccountWalletService.kt
- [ ] CloudIpInterceptor.kt
- [ ] CreateWebViewPaymentSdkUseCase.kt
- [ ] CreateWebViewPaymentOspUseCase.kt

**How should this be manually tested?**

After setting up the application with `SetUpCurrencyActivity`, verify that all requests made to the micro-services and backend have the `x-client-ip` and `x-client-country` correctly set.

**What are the relevant tickets?**

Tickets related to this pull-request: [DOT-139](https://aptoide.atlassian.net/browse/DOT-139)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] Database migration (if applicable)?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass


[DOT-139]: https://aptoide.atlassian.net/browse/DOT-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ